### PR TITLE
Add 504 errors to be retried together with 503 in iter_ methods

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/base.py
+++ b/dmapiclient/base.py
@@ -12,7 +12,7 @@ import backoff
 from monotonic import monotonic
 
 from . import __version__
-from .errors import APIError, HTTPError, HTTP503Error, InvalidResponse
+from .errors import APIError, HTTPError, HTTPTemporaryError, InvalidResponse
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +24,7 @@ def make_iter_method(method_name, model_name, url_path):
     :param model_name: The name of the model as it appears in the JSON response
     :param url_path: The URL path for the API
     """
-    backoff_decorator = backoff.on_exception(backoff.expo, HTTP503Error, max_tries=5)
+    backoff_decorator = backoff.on_exception(backoff.expo, HTTPTemporaryError, max_tries=5)
 
     def iter_method(self, *args, **kwargs):
         method = getattr(self, method_name)

--- a/dmapiclient/errors.py
+++ b/dmapiclient/errors.py
@@ -29,13 +29,13 @@ class HTTPError(APIError):
     @staticmethod
     def create(e):
         error = HTTPError(e.response)
-        if error.status_code == 503:
-            error = HTTP503Error(e.response)
+        if error.status_code in [503, 504]:
+            error = HTTPTemporaryError(e.response)
         return error
 
 
-class HTTP503Error(HTTPError):
-    """Specific instance of HTTPError for 503 errors
+class HTTPTemporaryError(HTTPError):
+    """Specific instance of HTTPError for temporary 503 and 504 errors
 
     Used for detecting whether failed requests should be retried.
     """


### PR DESCRIPTION
503 status is returned for all connection or response-related issues,
however it doesn't include the 504 responses returned by AWS ELBs for
occastional request failures. Since 504 requests should be retried
for GET requests the same way connection errors are, 504 is added
to the list of statuses that return the HTTP503Error exception.

Since HTTP503Error is a misleading name now, the exception is renamed
to `HTTPTemporaryError`.

This should fix the issues with the index-services job failing due
to 504 responses when listing the services.