### PR TITLE
Add method to update status of a draft

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.2.0'
+__version__ = '1.3.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/audit.py
+++ b/dmapiclient/audit.py
@@ -8,6 +8,7 @@ class AuditTypes(Enum):
     supplier_update = "supplier_update"
     create_draft_service = "create_draft_service"
     update_draft_service = "update_draft_service"
+    update_draft_service_status = "update_draft_service_status"
     complete_draft_service = "complete_draft_service"
     publish_draft_service = "publish_draft_service"
     delete_draft_service = "delete_draft_service"

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -405,6 +405,16 @@ class DataAPIClient(BaseAPIClient):
                 }
             })
 
+    def update_draft_service_status(self, draft_id, status, user):
+        data = {
+            "update_details": {
+                "updated_by": user
+            },
+            "services": {"status": status},
+        }
+
+        return self._post("/draft-services/{}/update-status".format(draft_id), data=data)
+
     def publish_draft_service(self, draft_id, user):
         return self._post(
             "/draft-services/{}/publish".format(draft_id),

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1150,6 +1150,24 @@ class TestDataApiClient(object):
             }
         }
 
+    def test_update_draft_service_status(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/draft-services/2/update-status",
+            json={"services": {"status": "failed"}},
+            status_code=200,
+        )
+
+        result = data_client.update_draft_service_status(2, 'failed', 'user')
+
+        assert result == {"services": {"status": "failed"}}
+        assert rmock.called
+        assert rmock.request_history[0].json() == {
+            'update_details': {
+                'updated_by': 'user'
+            },
+            'services': {'status': 'failed'}
+        }
+
     def test_update_draft_service(self, data_client, rmock):
         rmock.post(
             "http://baseurl/draft-services/2",


### PR DESCRIPTION
This adds a method to access the new API endpoint defined here:  https://github.com/alphagov/digitalmarketplace-api/pull/333

This PR need to be merged before the API PR, because it needs to use the new audit type defined here.