### PR TITLE
Role-based authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 Records breaking changes from major version bumps
 
+## 2.0.0
+
+PR: [#7](https://github.com/alphagov/digitalmarketplace-apiclient/pull/7)
+
+### What changed
+
+The `authenticate_user` method used to take a boolen flag to indicate if the user is a supplier user.
+It now takes a `role` parameter instead, and only returns the user if the role matches the specified 
+role of the retrieved user.
+
+### Example app change
+
+Old
+```
+user = api_client.authenticate_user("email_address", "password", supplier=False)
+```
+
+New
+```
+user = api_client.authenticate_user("email_address", "password", role='buyer')
+```
+
 ## 1.0.0
 
 PR: [#1](https://github.com/alphagov/digitalmarketplace-apiclient/pull/1)

--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.4.0'
+__version__ = '2.0.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -254,7 +254,7 @@ class DataAPIClient(BaseAPIClient):
                 raise
         return None
 
-    def authenticate_user(self, email_address, password, supplier=True):
+    def authenticate_user(self, email_address, password, role):
         try:
             response = self._post(
                 '/users/auth',
@@ -264,7 +264,7 @@ class DataAPIClient(BaseAPIClient):
                         "password": password,
                     }
                 })
-            if not supplier or "supplier" in response['users']:
+            if response and role == response['users']['role']:
                 return response
         except HTTPError as e:
             if e.status_code not in [400, 403, 404]:


### PR DESCRIPTION
As per @robyoung's comment here:
https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/210#discussion-diff-51412643R264

Rather than having a flag for `supplier` we can pass the desired user role in for authentication.