### PR TITLE
Role based authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ PR: [#8](https://github.com/alphagov/digitalmarketplace-apiclient/pull/8)
 ### What changed
 
 The `authenticate_user` method used to take a boolean flag to indicate if the user is a supplier user.
-It now takes an optional `role` parameter instead, and if `role` is specified then the authenticate method 
-will only returns the user if the role of the user matches the specified role.
+Now it just returns users with any role, and it is up to the front-end apps to decide if the authenticated
+user should be allowed to access a resource.
 
 ### Example app change
 
@@ -21,7 +21,7 @@ user = api_client.authenticate_user("email_address", "password", supplier=False)
 
 New
 ```
-user = api_client.authenticate_user("email_address", "password", role='buyer')
+user = api_client.authenticate_user("email_address", "password")
 ```
 
 ## 1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 Records breaking changes from major version bumps
 
+## 2.0.0
+
+PR: [#8](https://github.com/alphagov/digitalmarketplace-apiclient/pull/8)
+
+### What changed
+
+The `authenticate_user` method used to take a boolean flag to indicate if the user is a supplier user.
+It now takes an optional `role` parameter instead, and if `role` is specified then the authenticate method 
+will only returns the user if the role of the user matches the specified role.
+
+### Example app change
+
+Old
+```
+user = api_client.authenticate_user("email_address", "password", supplier=False)
+```
+
+New
+```
+user = api_client.authenticate_user("email_address", "password", role='buyer')
+```
+
 ## 1.0.0
 
 PR: [#1](https://github.com/alphagov/digitalmarketplace-apiclient/pull/1)

--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.4.0'
+__version__ = '2.0.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -254,7 +254,7 @@ class DataAPIClient(BaseAPIClient):
                 raise
         return None
 
-    def authenticate_user(self, email_address, password, role=None):
+    def authenticate_user(self, email_address, password):
         try:
             response = self._post(
                 '/users/auth',
@@ -264,13 +264,10 @@ class DataAPIClient(BaseAPIClient):
                         "password": password,
                     }
                 })
-            if response:
-                if not role or role == response['users']['role']:
-                    return response
+            return response if response else None
         except HTTPError as e:
             if e.status_code not in [400, 403, 404]:
                 raise
-        return None
 
     def update_user_password(self, user_id, new_password, updater="no logged-in user"):
         try:

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -254,7 +254,7 @@ class DataAPIClient(BaseAPIClient):
                 raise
         return None
 
-    def authenticate_user(self, email_address, password, supplier=True):
+    def authenticate_user(self, email_address, password, role=None):
         try:
             response = self._post(
                 '/users/auth',
@@ -264,8 +264,9 @@ class DataAPIClient(BaseAPIClient):
                         "password": password,
                     }
                 })
-            if not supplier or "supplier" in response['users']:
-                return response
+            if response:
+                if not role or role == response['users']['role']:
+                    return response
         except HTTPError as e:
             if e.status_code not in [400, 403, 404]:
                 raise

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1481,6 +1481,28 @@ class TestDataApiClient(object):
 
             data_client.get_framework_stats('g-cloud-11')
 
+    def test_find_frameworks(self, data_client, rmock):
+        rmock.get(
+            'http://baseurl/frameworks',
+            json={'frameworks': ['g6', 'g7']},
+            status_code=200)
+
+        result = data_client.find_frameworks()
+
+        assert result == {'frameworks': ['g6', 'g7']}
+        assert rmock.called
+
+    def test_get_framework(self, data_client, rmock):
+        rmock.get(
+            'http://baseurl/frameworks/g-cloud-11',
+            json={'frameworks': {'g-cloud-11': 'yes'}},
+            status_code=200)
+
+        result = data_client.get_framework('g-cloud-11')
+
+        assert result == {'frameworks': {'g-cloud-11': 'yes'}}
+        assert rmock.called
+
 
 class TestDataAPIClientIterMethods(object):
     def _test_find_iter(self, data_client, rmock, method_name, model_name, url_path):

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -560,8 +560,7 @@ class TestDataApiClient(object):
             json=self.user(),
             status_code=200)
 
-        user = data_client.authenticate_user(
-            "email_address", "password", "supplier")['users']
+        user = data_client.authenticate_user("email_address", "password")['users']
 
         assert user['id'] == "id"
         assert user['email_address'] == "email_address"
@@ -575,8 +574,7 @@ class TestDataApiClient(object):
             text=json.dumps({'authorization': False}),
             status_code=404)
 
-        user = data_client.authenticate_user(
-            "email_address", "password", "supplier")
+        user = data_client.authenticate_user("email_address", "password")
 
         assert user is None
 
@@ -587,8 +585,7 @@ class TestDataApiClient(object):
             text=json.dumps({'authorization': False}),
             status_code=403)
 
-        user = data_client.authenticate_user(
-            "email_address", "password", "supplier")
+        user = data_client.authenticate_user("email_address", "password")
 
         assert user is None
 
@@ -599,28 +596,11 @@ class TestDataApiClient(object):
             text=json.dumps({'authorization': False}),
             status_code=400)
 
-        user = data_client.authenticate_user(
-            "email_address", "password", "supplier")
+        user = data_client.authenticate_user("email_address", "password")
 
         assert user is None
 
-    def test_authenticate_user_returns_none_on_non_supplier_if_supplier_role(
-            self, data_client, rmock):
-        user_with_no_supplier = self.user()
-        del user_with_no_supplier['users']['supplier']
-        user_with_no_supplier['users']['role'] = 'not-supplier'
-
-        rmock.post(
-            'http://baseurl/users/auth',
-            text=json.dumps(user_with_no_supplier),
-            status_code=200)
-
-        user = data_client.authenticate_user(
-            "email_address", "password", "supplier")
-
-        assert user is None
-
-    def test_authenticate_user_returns_buyer_user_if_buyer_role(
+    def test_authenticate_user_returns_buyer_user(
             self, data_client, rmock):
         user_with_no_supplier = self.user()
         del user_with_no_supplier['users']['supplier']
@@ -631,8 +611,7 @@ class TestDataApiClient(object):
             text=json.dumps(user_with_no_supplier),
             status_code=200)
 
-        user = data_client.authenticate_user(
-            "email_address", "password", "buyer")
+        user = data_client.authenticate_user("email_address", "password")
 
         assert user == user_with_no_supplier
 
@@ -643,7 +622,7 @@ class TestDataApiClient(object):
                 text=json.dumps({'authorization': False}),
                 status_code=500)
 
-            data_client.authenticate_user("email_address", "password", "supplier")
+            data_client.authenticate_user("email_address", "password")
 
     def test_create_user(self, data_client, rmock):
         rmock.post(


### PR DESCRIPTION
As per @robyoung's comment here:
alphagov/digitalmarketplace-buyer-frontend#210 (diff)

Rather than having a flag for supplier we can pass the desired user role in for authentication.

**QUESTION:** Do we actually need this `role` parameter at all now?  The login route in the buyer app is for logging in buyers or suppliers, so when do we actually need to authenticate against a specific role?  It doesn't hurt to have it here, but I'm not sure we need it.