### PR TITLE
Add stubs for use in tests

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.1.0'
+__version__ = '2.2.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/api_stubs.py
+++ b/dmapiclient/api_stubs.py
@@ -1,0 +1,30 @@
+
+def framework(status="open", slug="g-cloud-7", name=None, clarification_questions_open=True, lots=None):
+    if slug == "g-cloud-7":
+        name = "G-Cloud 7"
+    elif slug == "digital-outcomes-and-specialists":
+        name = "Digital Outcomes and Specialists"
+    else:
+        name = slug.replace("-", " ").title()
+
+    lots = lots or []
+
+    return {
+        "frameworks": {
+            "status": status,
+            "clarificationQuestionsOpen": clarification_questions_open,
+            "name": name,
+            "slug": slug,
+            "lots": lots,
+        }
+    }
+
+
+def lot(slug="some-lot", allows_brief=False, one_service_limit=False):
+    return {
+        "id": 1,
+        "slug": slug,
+        "name": slug.replace("-", " ").title(),
+        "allowsBrief": allows_brief,
+        "oneServiceLimit": one_service_limit,
+    }

--- a/tests/test_api_stubs.py
+++ b/tests/test_api_stubs.py
@@ -1,0 +1,33 @@
+from dmapiclient import api_stubs
+
+
+def test_framework():
+    assert api_stubs.framework() == {
+        "frameworks": {
+            "clarificationQuestionsOpen": True,
+            "lots": [],
+            "name": "G-Cloud 7",
+            "slug": "g-cloud-7",
+            "status": "open",
+        }
+    }
+
+
+def test_framework_name_changes_with_slug():
+    assert api_stubs.framework(slug='digital-outcomes-and-specialists')["frameworks"]["name"] == \
+        "Digital Outcomes and Specialists"
+    assert api_stubs.framework(slug="my-framework")["frameworks"]["name"] == "My Framework"
+
+
+def test_lot_name_default_is_made_from_slug():
+    assert api_stubs.lot(slug="my-lot")["name"] == "My Lot"
+
+
+def test_lot():
+    assert api_stubs.lot(slug="foo") == {
+        "id": 1,
+        "slug": "foo",
+        "name": "Foo",
+        "allowsBrief": False,
+        "oneServiceLimit": False,
+    }


### PR DESCRIPTION
Now that we have complex API interactions in the buyers app it would be useful to have common API response factories somewhere they can be shared between the frontend apps.

We have decided not to look at Factory Boy right now as our use case is pretty simple.

## Example use
```python
api_stubs.framework(
  slug="my-framework",
  lots=[
    api_stubs.lot(slug="my-lot", allows_brief=False)
  ]
)
```