### PR TITLE
Add create_brief_response audit event type

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.2.0'
+__version__ = '2.3.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/audit.py
+++ b/dmapiclient/audit.py
@@ -32,6 +32,7 @@ class AuditTypes(Enum):
     create_brief = "create_brief"
     update_brief = "update_brief"
     update_brief_status = "update_brief_status"
+    create_brief_response = "create_brief_response"
 
     @staticmethod
     def is_valid_audit_type(test_audit_type):


### PR DESCRIPTION
Used when supplier submits a brief response. Since responses are
not editable at the moment we don't need any other event types.