### PR TITLE
Update briefs client methods

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.3.0'
+__version__ = '2.3.1'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/api_stubs.py
+++ b/dmapiclient/api_stubs.py
@@ -28,3 +28,19 @@ def lot(slug="some-lot", allows_brief=False, one_service_limit=False):
         "allowsBrief": allows_brief,
         "oneServiceLimit": one_service_limit,
     }
+
+
+def brief(status="draft", framework_slug="digital-outcomes-and-specialists", lot_slug="digital-specialists"):
+    return {
+        "briefs": {
+            "id": 1234,
+            "frameworkSlug": framework_slug,
+            "lotSlug": lot_slug,
+            "status": status,
+            'users': [{"active": True,
+                       "role": "buyer",
+                       "emailAddress": "buyer@email.com",
+                       "id": 123,
+                       "name": "Buyer User"}],
+        }
+    }

--- a/dmapiclient/api_stubs.py
+++ b/dmapiclient/api_stubs.py
@@ -30,7 +30,10 @@ def lot(slug="some-lot", allows_brief=False, one_service_limit=False):
     }
 
 
-def brief(status="draft", framework_slug="digital-outcomes-and-specialists", lot_slug="digital-specialists"):
+def brief(status="draft",
+          framework_slug="digital-outcomes-and-specialists",
+          lot_slug="digital-specialists",
+          user_id=123):
     return {
         "briefs": {
             "id": 1234,
@@ -40,7 +43,7 @@ def brief(status="draft", framework_slug="digital-outcomes-and-specialists", lot
             'users': [{"active": True,
                        "role": "buyer",
                        "emailAddress": "buyer@email.com",
-                       "id": 123,
+                       "id": user_id,
                        "name": "Buyer User"}],
         }
     }

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -513,29 +513,33 @@ class DataAPIClient(BaseAPIClient):
 
     # Buyer briefs
 
-    def create_brief(self, framework, lot, brief_title, user_id, user):
+    def create_brief(self, framework_slug, lot_slug, user_id, data, updated_by, page_questions=None):
+        brief_data = data.copy()
+        brief_data.update({
+            "frameworkSlug": framework_slug,
+            "lot": lot_slug,
+            "userId": user_id,
+        })
         return self._post(
             "/briefs",
             data={
-                "briefs": {
-                    "frameworkSlug": framework,
-                    "lot": lot,
-                    "userId": user_id,
-                    "title": brief_title
-                },
+                "briefs": brief_data,
                 "update_details": {
-                    "updated_by": user
-                }
-            })
+                    "updated_by": updated_by
+                },
+                "page_questions": page_questions or [],
+            }
+        )
 
-    def update_brief(self, brief_id, brief, user):
+    def update_brief(self, brief_id, brief, updated_by, page_questions=None):
         return self._post(
             "/briefs/{}".format(brief_id),
             data={
                 "briefs": brief,
                 "update_details": {
-                    "updated_by": user
-                }
+                    "updated_by": updated_by
+                },
+                "page_questions": page_questions or [],
             },
         )
 

--- a/tests/test_api_stubs.py
+++ b/tests/test_api_stubs.py
@@ -34,7 +34,8 @@ def test_lot():
 
 
 def test_brief():
-    assert api_stubs.brief(status='published', framework_slug='a-framework-slug', lot_slug='a-lot-slug') == {
+    assert api_stubs.brief(status='published', framework_slug='a-framework-slug', lot_slug='a-lot-slug', user_id=234)\
+        == {
         "briefs": {
             "id": 1234,
             "frameworkSlug": "a-framework-slug",
@@ -43,7 +44,7 @@ def test_brief():
             'users': [{"active": True,
                        "role": "buyer",
                        "emailAddress": "buyer@email.com",
-                       "id": 123,
+                       "id": 234,
                        "name": "Buyer User"}],
         }
     }

--- a/tests/test_api_stubs.py
+++ b/tests/test_api_stubs.py
@@ -31,3 +31,19 @@ def test_lot():
         "allowsBrief": False,
         "oneServiceLimit": False,
     }
+
+
+def test_brief():
+    assert api_stubs.brief(status='published', framework_slug='a-framework-slug', lot_slug='a-lot-slug') == {
+        "briefs": {
+            "id": 1234,
+            "frameworkSlug": "a-framework-slug",
+            "lotSlug": "a-lot-slug",
+            "status": "published",
+            'users': [{"active": True,
+                       "role": "buyer",
+                       "emailAddress": "buyer@email.com",
+                       "id": 123,
+                       "name": "Buyer User"}],
+        }
+    }

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1510,7 +1510,11 @@ class TestDataApiClient(object):
             status_code=201,
         )
 
-        result = data_client.create_brief("digital-things", "digital-watches", "Timex", 123, "user@email.com")
+        result = data_client.create_brief(
+            "digital-things", "digital-watches", 123,
+            {"title": "Timex"},
+            "user@email.com",
+            page_questions=["title"])
 
         assert result == {"briefs": "result"}
         assert rmock.last_request.json() == {
@@ -1522,7 +1526,8 @@ class TestDataApiClient(object):
             },
             "update_details": {
                 "updated_by": "user@email.com"
-            }
+            },
+            "page_questions": ["title"],
         }
 
     def test_update_brief(self, data_client, rmock):
@@ -1539,7 +1544,8 @@ class TestDataApiClient(object):
             "briefs": {"foo": "bar"},
             "update_details": {
                 "updated_by": "user@email.com"
-            }
+            },
+            "page_questions": [],
         }
 
     def test_update_brief_status(self, data_client, rmock):


### PR DESCRIPTION
Updated methods to match current API format for brief endpoints.
Also adds a `briefs` helper for tests.