### PR TITLE
Add delete brief method and add timestamps to brief stubs

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.3.1'
+__version__ = '2.3.2'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/api_stubs.py
+++ b/dmapiclient/api_stubs.py
@@ -34,16 +34,22 @@ def brief(status="draft",
           framework_slug="digital-outcomes-and-specialists",
           lot_slug="digital-specialists",
           user_id=123):
-    return {
+    brief = {
         "briefs": {
             "id": 1234,
+            "title": "I need a thing to do a thing",
             "frameworkSlug": framework_slug,
             "lotSlug": lot_slug,
             "status": status,
-            'users': [{"active": True,
+            "users": [{"active": True,
                        "role": "buyer",
                        "emailAddress": "buyer@email.com",
                        "id": user_id,
                        "name": "Buyer User"}],
+            "createdAt": "2016-03-29T10:11:12.000000Z",
+            "updatedAt": "2016-03-29T10:11:13.000000Z"
         }
     }
+    if status == "live":
+        brief['briefs']['publishedAt'] = "2016-03-29T10:11:14.000000Z"
+    return brief

--- a/dmapiclient/audit.py
+++ b/dmapiclient/audit.py
@@ -4,35 +4,48 @@ from enum import Enum, unique
 @unique
 class AuditTypes(Enum):
 
+    # User account events
+    create_user = "create_user"
+    update_user = "update_user"
+    invite_user = "invite_user"
+    user_auth_failed = "user_auth_failed"
     contact_update = "contact_update"
     supplier_update = "supplier_update"
+
+    # Draft service lifecycle event
     create_draft_service = "create_draft_service"
     update_draft_service = "update_draft_service"
     update_draft_service_status = "update_draft_service_status"
     complete_draft_service = "complete_draft_service"
     publish_draft_service = "publish_draft_service"
     delete_draft_service = "delete_draft_service"
+
+    # Live service lifecycle events
     update_service = "update_service"
     import_service = "import_service"
     update_service_status = "update_service_status"
-    user_auth_failed = "user_auth_failed"
-    create_user = "create_user"
-    update_user = "update_user"
-    answer_selection_questions = "answer_selection_questions"
-    register_framework_interest = "register_framework_interest"
-    invite_user = "invite_user"
-    send_clarification_question = "send_clarification_question"
-    view_clarification_questions = "view_clarification_questions"
-    send_application_question = "send_application_question"
-    send_g7_application_question = "send_g7_application_question"
-    snapshot_framework_stats = "snapshot_framework_stats"
-    framework_update = "framework_update"
-    upload_countersigned_agreement = "upload_countersigned_agreement"
-    delete_countersigned_agreement = "delete_countersigned_agreement"
+
+    # Brief lifecycle events
     create_brief = "create_brief"
     update_brief = "update_brief"
     update_brief_status = "update_brief_status"
     create_brief_response = "create_brief_response"
+    delete_brief = "delete_brief"
+
+    # Supplier actions
+    register_framework_interest = "register_framework_interest"
+    view_clarification_questions = "view_clarification_questions"
+    send_clarification_question = "send_clarification_question"
+    send_application_question = "send_application_question"
+    answer_selection_questions = "answer_selection_questions"
+
+    # Framework lifecycle
+    framework_update = "framework_update"
+
+    # Admin actions
+    upload_countersigned_agreement = "upload_countersigned_agreement"
+    delete_countersigned_agreement = "delete_countersigned_agreement"
+    snapshot_framework_stats = "snapshot_framework_stats"
 
     @staticmethod
     def is_valid_audit_type(test_audit_type):

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -563,3 +563,12 @@ class DataAPIClient(BaseAPIClient):
             "/briefs",
             params={"user_id": user_id}
         )
+
+    def delete_brief(self, brief_id, user):
+        return self._delete(
+            "/briefs/{}".format(brief_id),
+            data={
+                "update_details": {
+                    "updated_by": user
+                },
+            })

--- a/tests/test_api_stubs.py
+++ b/tests/test_api_stubs.py
@@ -34,17 +34,39 @@ def test_lot():
 
 
 def test_brief():
-    assert api_stubs.brief(status='published', framework_slug='a-framework-slug', lot_slug='a-lot-slug', user_id=234)\
+    assert api_stubs.brief() \
         == {
         "briefs": {
             "id": 1234,
+            "title": "I need a thing to do a thing",
+            "frameworkSlug": "digital-outcomes-and-specialists",
+            "lotSlug": "digital-specialists",
+            "status": "draft",
+            "users": [{"active": True,
+                       "role": "buyer",
+                       "emailAddress": "buyer@email.com",
+                       "id": 123,
+                       "name": "Buyer User"}],
+            "createdAt": "2016-03-29T10:11:12.000000Z",
+            "updatedAt": "2016-03-29T10:11:13.000000Z"
+        }
+    }
+
+    assert api_stubs.brief(status='live', framework_slug='a-framework-slug', lot_slug='a-lot-slug', user_id=234) \
+        == {
+        "briefs": {
+            "id": 1234,
+            "title": "I need a thing to do a thing",
             "frameworkSlug": "a-framework-slug",
             "lotSlug": "a-lot-slug",
-            "status": "published",
-            'users': [{"active": True,
+            "status": "live",
+            "users": [{"active": True,
                        "role": "buyer",
                        "emailAddress": "buyer@email.com",
                        "id": 234,
                        "name": "Buyer User"}],
+            "createdAt": "2016-03-29T10:11:12.000000Z",
+            "updatedAt": "2016-03-29T10:11:13.000000Z",
+            "publishedAt": "2016-03-29T10:11:14.000000Z"
         }
     }

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1595,6 +1595,25 @@ class TestDataApiClient(object):
 
         assert result == {"briefs": []}
 
+    def test_delete_brief(self, data_client, rmock):
+        rmock.delete(
+            "http://baseurl/briefs/2",
+            json={"done": "it"},
+            status_code=200,
+        )
+
+        result = data_client.delete_brief(
+            2, 'user'
+        )
+
+        assert result == {"done": "it"}
+        assert rmock.called
+        assert rmock.request_history[0].json() == {
+            'update_details': {
+                'updated_by': 'user'
+            }
+        }
+
 
 class TestDataAPIClientIterMethods(object):
     def _test_find_iter(self, data_client, rmock, method_name, model_name, url_path):


### PR DESCRIPTION
The brief summary page looks at the last updated time, and will also show the published time for live briefs, so it's useful to have the timestamps in the `brief()` api stub helper.

Also adds a title for the brief, also for testing the brief summary page.

This also now adds an apiclient method for the delete_brief API endpoint that now exists here: https://github.com/alphagov/digitalmarketplace-api/pull/351
(But this will need to be merged first, because the API needs the new audit type introduced here.)