### PR TITLE
Brief responses apiclient methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 Records breaking changes from major version bumps
 
+## 3.0.0
+
+PR: [#14](https://github.com/alphagov/digitalmarketplace-apiclient/pull/14)
+
+### What changed
+
+All POST, PUT and DELETE methods are now sending `"updated_by"` payload instead of `"update_details"`.
+The new payload should be supported by the data API for all methods.
+
+This shouldn't require any changes to the code that's using `DataAPIClient`, but might break test
+expectations if any of them rely on `update_details` payload key.
+
+### Example app change
+
+Search for `update_details` and replace all instances of `{"update_details": {"updated_by": ...}}` with
+`{"updated_by": ...}` if they affect the tests.
+
 ## 2.0.0
 
 PR: [#8](https://github.com/alphagov/digitalmarketplace-apiclient/pull/8)

--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.3.2'
+__version__ = '3.0.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/base.py
+++ b/dmapiclient/base.py
@@ -51,14 +51,26 @@ class BaseAPIClient(object):
     def _put(self, url, data):
         return self._request("PUT", url, data=data)
 
+    def _put_with_updated_by(self, url, data, user):
+        data = dict(data, updated_by=user)
+        return self._put(url, data)
+
     def _get(self, url, params=None):
         return self._request("GET", url, params=params)
 
     def _post(self, url, data):
         return self._request("POST", url, data=data)
 
+    def _post_with_updated_by(self, url, data, user):
+        data = dict(data, updated_by=user)
+        return self._post(url, data)
+
     def _delete(self, url, data=None):
         return self._request("DELETE", url, data=data)
+
+    def _delete_with_updated_by(self, url, data, user):
+        data = dict(data, updated_by=user)
+        return self._delete(url, data)
 
     def _request(self, method, url, data=None, params=None):
         if not self.enabled:

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -50,13 +50,11 @@ class DataAPIClient(BaseAPIClient):
     find_audit_events_iter = make_iter_method('find_audit_events', 'auditEvents', 'audit-events')
 
     def acknowledge_audit_event(self, audit_event_id, user):
-        return self._post(
+        return self._post_with_updated_by(
             "/audit-events/{}/acknowledge".format(audit_event_id),
-            data={
-                "update_details": {
-                    "updated_by": user
-                }
-            })
+            data={},
+            user=user,
+        )
 
     def create_audit_event(self, audit_type, user=None, data=None, object_type=None, object_id=None):
         if not isinstance(audit_type, AuditTypes):
@@ -116,23 +114,23 @@ class DataAPIClient(BaseAPIClient):
         )
 
     def update_supplier(self, supplier_id, supplier, user):
-        return self._post(
+        return self._post_with_updated_by(
             "/suppliers/{}".format(supplier_id),
             data={
                 "suppliers": supplier,
-                "updated_by": user,
             },
+            user=user,
         )
 
     def update_contact_information(self, supplier_id, contact_id,
                                    contact, user):
-        return self._post(
+        return self._post_with_updated_by(
             "/suppliers/{}/contact-information/{}".format(
                 supplier_id, contact_id),
             data={
                 "contactInformation": contact,
-                "updated_by": user,
             },
+            user=user,
         )
 
     def get_framework_interest(self, supplier_id):
@@ -141,14 +139,11 @@ class DataAPIClient(BaseAPIClient):
         )
 
     def register_framework_interest(self, supplier_id, framework_slug, user):
-        return self._put(
+        return self._put_with_updated_by(
             "/suppliers/{}/frameworks/{}".format(
                 supplier_id, framework_slug),
-            data={
-                "update_details": {
-                    "updated_by": user
-                }
-            },
+            data={},
+            user=user,
         )
 
     def get_supplier_declaration(self, supplier_id, framework_slug):
@@ -158,12 +153,12 @@ class DataAPIClient(BaseAPIClient):
         return {'declaration': response['frameworkInterest']['declaration']}
 
     def set_supplier_declaration(self, supplier_id, framework_slug, declaration, user):
-        return self._put(
+        return self._put_with_updated_by(
             "/suppliers/{}/frameworks/{}/declaration".format(supplier_id, framework_slug),
             data={
-                "updated_by": user,
                 "declaration": declaration
-            }
+            },
+            user=user
         )
 
     def get_supplier_frameworks(self, supplier_id):
@@ -177,27 +172,23 @@ class DataAPIClient(BaseAPIClient):
         )
 
     def set_framework_result(self, supplier_id, framework_slug, is_on_framework, user):
-        return self._post(
+        return self._post_with_updated_by(
             "/suppliers/{}/frameworks/{}".format(
                 supplier_id, framework_slug),
             data={
                 "frameworkInterest": {"onFramework": is_on_framework},
-                "update_details": {
-                    "updated_by": user
-                }
             },
+            user=user,
         )
 
     def register_framework_agreement_returned(self, supplier_id, framework_slug, user):
-        return self._post(
+        return self._post_with_updated_by(
             "/suppliers/{}/frameworks/{}".format(
                 supplier_id, framework_slug),
             data={
                 "frameworkInterest": {"agreementReturned": True},
-                "update_details": {
-                    "updated_by": user
-                }
             },
+            user=user,
         )
 
     def find_framework_suppliers(self, framework_slug, agreement_returned=None):
@@ -271,14 +262,12 @@ class DataAPIClient(BaseAPIClient):
 
     def update_user_password(self, user_id, new_password, updater="no logged-in user"):
         try:
-            self._post(
+            self._post_with_updated_by(
                 '/users/{}'.format(user_id),
                 data={
                     "users": {"password": new_password},
-                    "update_details": {
-                        "updated_by": updater
-                    }
-                }
+                },
+                user=updater,
             )
             return True
         except HTTPError as e:
@@ -314,14 +303,12 @@ class DataAPIClient(BaseAPIClient):
 
         params = {
             "users": fields,
-            "update_details": {
-                "updated_by": updater
-            }
         }
 
-        user = self._post(
+        user = self._post_with_updated_by(
             '/users/{}'.format(user_id),
-            data=params
+            data=params,
+            user=updater,
         )
 
         logger.info("Updated user {user_id} fields {params}",
@@ -355,72 +342,60 @@ class DataAPIClient(BaseAPIClient):
         )
 
     def delete_draft_service(self, draft_id, user):
-        return self._delete(
+        return self._delete_with_updated_by(
             "/draft-services/{}".format(draft_id),
-            data={
-                "update_details": {
-                    "updated_by": user
-                },
-            })
+            data={},
+            user=user,
+        )
 
     def copy_draft_service_from_existing_service(self, service_id, user):
-        return self._put(
+        return self._put_with_updated_by(
             "/draft-services/copy-from/{}".format(service_id),
-            data={
-                "update_details": {
-                    "updated_by": user
-                },
-            })
+            data={},
+            user=user,
+        )
 
     def copy_draft_service(self, draft_id, user):
-        return self._post(
+        return self._post_with_updated_by(
             "/draft-services/{}/copy".format(draft_id),
-            data={
-                "update_details": {
-                    "updated_by": user
-                }
-            })
+            data={},
+            user=user,
+        )
 
     def update_draft_service(self, draft_id, service, user, page_questions=None):
         data = {
-            "update_details": {
-                "updated_by": user
-            },
             "services": service,
         }
 
         if page_questions is not None:
             data['page_questions'] = page_questions
 
-        return self._post("/draft-services/{}".format(draft_id), data=data)
+        return self._post_with_updated_by("/draft-services/{}".format(draft_id), data=data, user=user)
 
     def complete_draft_service(self, draft_id, user):
-        return self._post(
+        return self._post_with_updated_by(
             "/draft-services/{}/complete".format(draft_id),
-            data={
-                "update_details": {
-                    "updated_by": user
-                }
-            })
+            data={},
+            user=user,
+        )
 
     def update_draft_service_status(self, draft_id, status, user):
         data = {
-            "update_details": {
-                "updated_by": user
-            },
             "services": {"status": status},
         }
 
-        return self._post("/draft-services/{}/update-status".format(draft_id), data=data)
+        return self._post_with_updated_by(
+            "/draft-services/{}/update-status".format(draft_id),
+            data=data,
+            user=user,
+        )
 
     def publish_draft_service(self, draft_id, user):
-        return self._post(
+        return self._post_with_updated_by(
             "/draft-services/{}/publish".format(draft_id),
-            data={
-                "update_details": {
-                    "updated_by": user
-                },
-            })
+            data={},
+            user=user,
+        )
 
     def create_new_draft_service(self, framework_slug, lot, supplier_id, data, user, page_questions=None):
         service_data = data.copy()
@@ -430,16 +405,14 @@ class DataAPIClient(BaseAPIClient):
             "supplierId": supplier_id,
         })
 
-        return self._post(
+        return self._post_with_updated_by(
             "/draft-services",
             data={
-                "update_details": {
-                    "updated_by": user
-                },
-
                 "services": service_data,
                 "page_questions": page_questions or [],
-            })
+            },
+            user=user,
+        )
 
     def get_archived_service(self, archived_service_id):
         return self._get("/archived-services/{}".format(archived_service_id))
@@ -466,33 +439,29 @@ class DataAPIClient(BaseAPIClient):
     find_services_iter = make_iter_method('find_services', 'services', 'services')
 
     def import_service(self, service_id, service, user):
-        return self._put(
+        return self._put_with_updated_by(
             "/services/{}".format(service_id),
             data={
-                "update_details": {
-                    "updated_by": user
-                },
                 "services": service,
-            })
+            },
+            user=user,
+        )
 
     def update_service(self, service_id, service, user):
-        return self._post(
+        return self._post_with_updated_by(
             "/services/{}".format(service_id),
             data={
-                "update_details": {
-                    "updated_by": user
-                },
                 "services": service,
-            })
+            },
+            user=user,
+        )
 
     def update_service_status(self, service_id, status, user):
-        return self._post(
+        return self._post_with_updated_by(
             "/services/{}/status/{}".format(service_id, status),
-            data={
-                "update_details": {
-                    "updated_by": user
-                },
-            })
+            data={},
+            user=user,
+        )
 
     def find_frameworks(self):
         return self._get("/frameworks")
@@ -520,38 +489,32 @@ class DataAPIClient(BaseAPIClient):
             "lot": lot_slug,
             "userId": user_id,
         })
-        return self._post(
+        return self._post_with_updated_by(
             "/briefs",
             data={
                 "briefs": brief_data,
-                "update_details": {
-                    "updated_by": updated_by
-                },
                 "page_questions": page_questions or [],
-            }
+            },
+            user=updated_by,
         )
 
     def update_brief(self, brief_id, brief, updated_by, page_questions=None):
-        return self._post(
+        return self._post_with_updated_by(
             "/briefs/{}".format(brief_id),
             data={
                 "briefs": brief,
-                "update_details": {
-                    "updated_by": updated_by
-                },
                 "page_questions": page_questions or [],
             },
+            user=updated_by,
         )
 
     def update_brief_status(self, brief_id, status, user):
-        return self._put(
+        return self._put_with_updated_by(
             "/briefs/{}/status".format(brief_id),
             data={
                 "briefs": {"status": status},
-                "update_details": {
-                    "updated_by": user
-                }
             },
+            user=user,
         )
 
     def get_brief(self, brief_id):
@@ -565,10 +528,8 @@ class DataAPIClient(BaseAPIClient):
         )
 
     def delete_brief(self, brief_id, user):
-        return self._delete(
+        return self._delete_with_updated_by(
             "/briefs/{}".format(brief_id),
-            data={
-                "update_details": {
-                    "updated_by": user
-                },
-            })
+            data={},
+            user=user,
+        )

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -533,3 +533,26 @@ class DataAPIClient(BaseAPIClient):
             data={},
             user=user,
         )
+
+    def create_brief_response(self, brief_id, supplier_id, data, user):
+        data = dict(data, briefId=brief_id, supplierId=supplier_id)
+        return self._post_with_updated_by(
+            "/brief-responses",
+            data={
+                "briefResponses": data
+            },
+            user=user,
+        )
+
+    def get_brief_response(self, brief_response_id):
+        return self._get(
+            "/brief-responses/{}".format(brief_response_id))
+
+    def find_brief_responses(self, brief_id=None, supplier_id=None):
+        return self._get(
+            "/brief-responses",
+            params={
+                "brief_id": brief_id,
+                "supplier_id": supplier_id,
+            }
+        )

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1582,6 +1582,47 @@ class TestDataApiClient(object):
             'updated_by': 'user'
         }
 
+    def test_create_brief_response(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/brief-responses",
+            json={"briefs": "result"},
+            status_code=201,
+        )
+
+        result = data_client.create_brief_response(
+            1, 2, {"essentialRequirements": [True, None, False]}, "user@email.com"
+        )
+
+        assert result == {"briefs": "result"}
+        assert rmock.last_request.json() == {
+            "briefResponses": {
+                "briefId": 1,
+                "supplierId": 2,
+                "essentialRequirements": [True, None, False],
+            },
+            "updated_by": "user@email.com"
+        }
+
+    def test_get_brief_response(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/brief-responses/123",
+            json={"briefResponses": "result"},
+            status_code=200)
+
+        result = data_client.get_brief_response(123)
+
+        assert result == {"briefResponses": "result"}
+
+    def test_find_brief_responses(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/brief-responses?brief_id=1&supplier_id=2",
+            json={"briefResponses": []},
+            status_code=200)
+
+        result = data_client.find_brief_responses(brief_id=1, supplier_id=2)
+
+        assert result == {"briefResponses": []}
+
 
 class TestDataAPIClientIterMethods(object):
     def _test_find_iter(self, data_client, rmock, method_name, model_name, url_path):

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -645,9 +645,7 @@ class TestDataApiClient(object):
             "users": {
                 "password": "newpassword"
             },
-            "update_details": {
-                "updated_by": "no logged-in user"
-            }
+            "updated_by": "no logged-in user"
         }
 
     def test_update_user_password_by_logged_in_user(self, data_client, rmock):
@@ -660,9 +658,7 @@ class TestDataApiClient(object):
             "users": {
                 "password": "newpassword"
             },
-            "update_details": {
-                "updated_by": "test@example.com"
-            }
+            "updated_by": "test@example.com"
         }
 
     def test_update_user_password_returns_false_on_non_200(
@@ -693,7 +689,7 @@ class TestDataApiClient(object):
         data_client.update_user(123, role='supplier', updater="test@example.com")
         assert rmock.called
         assert rmock.last_request.json() == {
-            "update_details": {"updated_by": "test@example.com"},
+            "updated_by": "test@example.com",
             "users": {"role": 'supplier'}
         }
 
@@ -705,7 +701,7 @@ class TestDataApiClient(object):
         data_client.update_user(123, supplier_id=123, updater="test@example.com")
         assert rmock.called
         assert rmock.last_request.json() == {
-            "update_details": {"updated_by": "test@example.com"},
+            "updated_by": "test@example.com",
             "users": {"supplierId": 123}
         }
 
@@ -717,7 +713,7 @@ class TestDataApiClient(object):
         data_client.update_user(123, supplier_id=123, role='supplier', updater="test@example.com")
         assert rmock.called
         assert rmock.last_request.json() == {
-            "update_details": {"updated_by": "test@example.com"},
+            "updated_by": "test@example.com",
             "users": {
                 "supplierId": 123,
                 "role": "supplier"
@@ -732,7 +728,7 @@ class TestDataApiClient(object):
         data_client.update_user(123, locked=False, updater="test@example.com")
         assert rmock.called
         assert rmock.last_request.json() == {
-            "update_details": {"updated_by": "test@example.com"},
+            "updated_by": "test@example.com",
             "users": {"locked": False}
         }
 
@@ -744,7 +740,7 @@ class TestDataApiClient(object):
         data_client.update_user(123, active=True, updater="test@example.com")
         assert rmock.called
         assert rmock.last_request.json() == {
-            "update_details": {"updated_by": "test@example.com"},
+            "updated_by": "test@example.com",
             "users": {"active": True}
         }
 
@@ -756,7 +752,7 @@ class TestDataApiClient(object):
         data_client.update_user(123, active=False, updater="test@example.com")
         assert rmock.called
         assert rmock.last_request.json() == {
-            "update_details": {"updated_by": "test@example.com"},
+            "updated_by": "test@example.com",
             "users": {"active": False}
         }
 
@@ -951,7 +947,7 @@ class TestDataApiClient(object):
 
         assert result == {"frameworkInterest": {"supplierId": 123, "frameworkId": 19}}
         assert rmock.called
-        assert rmock.request_history[0].json() == {'update_details': {'updated_by': 'g-15-user'}}
+        assert rmock.request_history[0].json() == {'updated_by': 'g-15-user'}
 
     def test_get_supplier_declaration(self, data_client, rmock):
         rmock.get(
@@ -1009,7 +1005,7 @@ class TestDataApiClient(object):
         assert rmock.called
         assert rmock.request_history[0].json() == {
             'frameworkInterest': {'onFramework': True},
-            'update_details': {'updated_by': 'user'}
+            'updated_by': 'user'
         }
 
     def test_register_framework_agreement_returned(self, data_client, rmock):
@@ -1023,7 +1019,7 @@ class TestDataApiClient(object):
         assert rmock.called
         assert rmock.request_history[0].json() == {
             'frameworkInterest': {'agreementReturned': True},
-            'update_details': {'updated_by': 'user'}
+            'updated_by': 'user'
         }
 
     def test_find_framework_suppliers(self, data_client, rmock):
@@ -1087,9 +1083,7 @@ class TestDataApiClient(object):
         assert result == {"done": "it"}
         assert rmock.called
         assert rmock.request_history[0].json() == {
-            'update_details': {
-                'updated_by': 'user'
-            }
+            'updated_by': 'user'
         }
 
     def test_copy_draft_service_from_existing_service(
@@ -1107,9 +1101,7 @@ class TestDataApiClient(object):
         assert result == {"done": "it"}
         assert rmock.called
         assert rmock.request_history[0].json() == {
-            'update_details': {
-                'updated_by': 'user'
-            }
+            'updated_by': 'user'
         }
 
     def test_copy_draft_service(self, data_client, rmock):
@@ -1124,9 +1116,7 @@ class TestDataApiClient(object):
         assert result == {"done": "copy"}
         assert rmock.called
         assert rmock.request_history[0].json() == {
-            'update_details': {
-                'updated_by': 'user'
-            }
+            'updated_by': 'user'
         }
 
     def test_complete_draft_service(self, data_client, rmock):
@@ -1141,9 +1131,7 @@ class TestDataApiClient(object):
         assert result == {"done": "complete"}
         assert rmock.called
         assert rmock.request_history[0].json() == {
-            'update_details': {
-                'updated_by': 'user'
-            }
+            'updated_by': 'user'
         }
 
     def test_update_draft_service_status(self, data_client, rmock):
@@ -1158,9 +1146,7 @@ class TestDataApiClient(object):
         assert result == {"services": {"status": "failed"}}
         assert rmock.called
         assert rmock.request_history[0].json() == {
-            'update_details': {
-                'updated_by': 'user'
-            },
+            'updated_by': 'user',
             'services': {'status': 'failed'}
         }
 
@@ -1181,9 +1167,7 @@ class TestDataApiClient(object):
             'services': {
                 "field": "value"
             },
-            'update_details': {
-                'updated_by': 'user'
-            },
+            'updated_by': 'user'
         }
 
     def test_update_draft_service_with_page_questions(self, data_client, rmock):
@@ -1203,9 +1187,7 @@ class TestDataApiClient(object):
             'services': {
                 "field": "value"
             },
-            'update_details': {
-                'updated_by': 'user'
-            },
+            'updated_by': 'user',
             'page_questions': ['question1', 'question2']
         }
 
@@ -1223,9 +1205,7 @@ class TestDataApiClient(object):
         assert result == {"done": "it"}
         assert rmock.called
         assert rmock.request_history[0].json() == {
-            'update_details': {
-                'updated_by': 'user'
-            }
+            'updated_by': 'user'
         }
 
     def test_create_new_draft_service(self, data_client, rmock):
@@ -1243,9 +1223,7 @@ class TestDataApiClient(object):
         assert rmock.called
         assert rmock.request_history[0].json() == {
             'page_questions': [],
-            'update_details': {
-                'updated_by': 'user'
-            },
+            'updated_by': 'user',
             'services': {
                 'frameworkSlug': 'g-cloud-7',
                 'supplierId': 2,
@@ -1358,9 +1336,7 @@ class TestDataApiClient(object):
         assert rmock.called
         assert result == {"audit-event": "result"}
         assert rmock.request_history[0].json() == {
-            'update_details': {
-                'updated_by': 'user'
-            }
+            'updated_by': 'user'
         }
 
     def test_create_audit_event(self, data_client, rmock):
@@ -1524,10 +1500,8 @@ class TestDataApiClient(object):
                 "userId": 123,
                 "title": "Timex"
             },
-            "update_details": {
-                "updated_by": "user@email.com"
-            },
             "page_questions": ["title"],
+            "updated_by": "user@email.com"
         }
 
     def test_update_brief(self, data_client, rmock):
@@ -1542,10 +1516,8 @@ class TestDataApiClient(object):
         assert result == {"briefs": "result"}
         assert rmock.last_request.json() == {
             "briefs": {"foo": "bar"},
-            "update_details": {
-                "updated_by": "user@email.com"
-            },
             "page_questions": [],
+            "updated_by": "user@email.com"
         }
 
     def test_update_brief_status(self, data_client, rmock):
@@ -1560,9 +1532,7 @@ class TestDataApiClient(object):
         assert result == {"briefs": "result"}
         assert rmock.last_request.json() == {
             "briefs": {"status": "published"},
-            "update_details": {
-                "updated_by": "user@email.com"
-            }
+            "updated_by": "user@email.com"
         }
 
     def test_get_brief(self, data_client, rmock):
@@ -1609,9 +1579,7 @@ class TestDataApiClient(object):
         assert result == {"done": "it"}
         assert rmock.called
         assert rmock.request_history[0].json() == {
-            'update_details': {
-                'updated_by': 'user'
-            }
+            'updated_by': 'user'
         }
 
 


### PR DESCRIPTION
### Always send "updated_by" field instead of "update_details"
Now that API supports both "updated_by" and "update_details" keys
we can switch the apiclient to always send the same payload.

Adds helper methods to add user info to the request data for post,
put and delete requests.

Changes data API client methods to use the new helpers so that update
data is always sent in the same format.

### Add brief-responses data API client methods
Adds methods for creating, reading and listing brief responses.