### PR TITLE
Add brief clarification questions

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '3.1.0'
+__version__ = '3.2.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/api_stubs.py
+++ b/dmapiclient/api_stubs.py
@@ -33,7 +33,8 @@ def lot(slug="some-lot", allows_brief=False, one_service_limit=False):
 def brief(status="draft",
           framework_slug="digital-outcomes-and-specialists",
           lot_slug="digital-specialists",
-          user_id=123):
+          user_id=123,
+          clarification_questions=None):
     brief = {
         "briefs": {
             "id": 1234,
@@ -47,7 +48,8 @@ def brief(status="draft",
                        "id": user_id,
                        "name": "Buyer User"}],
             "createdAt": "2016-03-29T10:11:12.000000Z",
-            "updatedAt": "2016-03-29T10:11:13.000000Z"
+            "updatedAt": "2016-03-29T10:11:13.000000Z",
+            "clarificationQuestions": clarification_questions or []
         }
     }
     if status == "live":

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -554,5 +554,15 @@ class DataAPIClient(BaseAPIClient):
             params={
                 "brief_id": brief_id,
                 "supplier_id": supplier_id,
-            }
-        )
+            })
+
+    def add_brief_clarification_question(self, brief_id, question, answer, user):
+        return self._post_with_updated_by(
+            "/briefs/{}/clarification-questions".format(brief_id),
+            data={
+                "clarificationQuestion": {
+                    "question": question,
+                    "answer": answer,
+                }
+            },
+            user=user)

--- a/tests/test_api_stubs.py
+++ b/tests/test_api_stubs.py
@@ -48,7 +48,8 @@ def test_brief():
                        "id": 123,
                        "name": "Buyer User"}],
             "createdAt": "2016-03-29T10:11:12.000000Z",
-            "updatedAt": "2016-03-29T10:11:13.000000Z"
+            "updatedAt": "2016-03-29T10:11:13.000000Z",
+            "clarificationQuestions": [],
         }
     }
 
@@ -67,6 +68,29 @@ def test_brief():
                        "name": "Buyer User"}],
             "createdAt": "2016-03-29T10:11:12.000000Z",
             "updatedAt": "2016-03-29T10:11:13.000000Z",
-            "publishedAt": "2016-03-29T10:11:14.000000Z"
+            "publishedAt": "2016-03-29T10:11:14.000000Z",
+            "clarificationQuestions": [],
+        }
+    }
+
+    assert api_stubs.brief(clarification_questions=[{"question": "Why?", "answer": "Because"}]) \
+        == {
+        "briefs": {
+            "id": 1234,
+            "title": "I need a thing to do a thing",
+            "frameworkSlug": "digital-outcomes-and-specialists",
+            "lotSlug": "digital-specialists",
+            "status": "draft",
+            "users": [{"active": True,
+                       "role": "buyer",
+                       "emailAddress": "buyer@email.com",
+                       "id": 123,
+                       "name": "Buyer User"}],
+            "createdAt": "2016-03-29T10:11:12.000000Z",
+            "updatedAt": "2016-03-29T10:11:13.000000Z",
+            "clarificationQuestions": [{
+                "question": "Why?",
+                "answer": "Because"
+            }],
         }
     }

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1623,6 +1623,20 @@ class TestDataApiClient(object):
 
         assert result == {"briefResponses": []}
 
+    def test_add_brief_clarification_question(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/briefs/1/clarification-questions",
+            json={"briefs": "result"},
+            status_code=200)
+
+        result = data_client.add_brief_clarification_question(1, "Why?", "Because", "user@example.com")
+
+        assert result == {"briefs": "result"}
+        assert rmock.last_request.json() == {
+            "clarificationQuestion": {"question": "Why?", "answer": "Because"},
+            "updated_by": "user@example.com",
+        }
+
 
 class TestDataAPIClientIterMethods(object):
     def _test_find_iter(self, data_client, rmock, method_name, model_name, url_path):


### PR DESCRIPTION
Depends on https://github.com/alphagov/digitalmarketplace-api/pull/354

Add a method to add a clarification question to a brief.