### PR TITLE
Unset framework agreement returned

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '3.2.0'
+__version__ = '3.3.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -191,6 +191,16 @@ class DataAPIClient(BaseAPIClient):
             user=user,
         )
 
+    def unset_framework_agreement_returned(self, supplier_id, framework_slug, user):
+        return self._post_with_updated_by(
+            "/suppliers/{}/frameworks/{}".format(
+                supplier_id, framework_slug),
+            data={
+                "frameworkInterest": {"agreementReturned": False},
+            },
+            user=user,
+        )
+
     def find_framework_suppliers(self, framework_slug, agreement_returned=None):
         params = {}
         if agreement_returned is not None:

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1022,6 +1022,20 @@ class TestDataApiClient(object):
             'updated_by': 'user'
         }
 
+    def test_unset_framework_agreement_returned(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/suppliers/123/frameworks/g-cloud-7",
+            json={"frameworkInterest": {"agreementReturned": False}},
+            status_code=200)
+
+        result = data_client.unset_framework_agreement_returned(123, 'g-cloud-7', "user")
+        assert result == {"frameworkInterest": {"agreementReturned": False}}
+        assert rmock.called
+        assert rmock.request_history[0].json() == {
+            'frameworkInterest': {'agreementReturned': False},
+            'updated_by': 'user'
+        }
+
     def test_find_framework_suppliers(self, data_client, rmock):
         rmock.get(
             'http://baseurl/frameworks/g-cloud-7/suppliers',


### PR DESCRIPTION
### Add unset_framework_agreement_returned method
Sets supplier framework `agreementReturned` flag to `False`.
Required to remove outdated signed framework agreements after the
original agreement document has been changed and requires a new
signature.