### PR TITLE
[#114474769] Add client method for new check-buyer-email API route

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '3.3.0'
+__version__ = '3.4.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -330,7 +330,7 @@ class DataAPIClient(BaseAPIClient):
             "/users/export/{}".format(framework_slug)
         )
 
-    def email_address_has_valid_buyer_domain(self, email_address):
+    def is_email_address_with_valid_buyer_domain(self, email_address):
         return self._get(
             "/users/check-buyer-email", params={'email_address': email_address}
         )['valid']

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -330,6 +330,11 @@ class DataAPIClient(BaseAPIClient):
             "/users/export/{}".format(framework_slug)
         )
 
+    def email_address_has_valid_buyer_domain(self, email_address):
+        return self._get(
+            "/users/check-buyer-email", params={'email_address': email_address}
+        )['valid']
+
     # Services
 
     def find_draft_services(self, supplier_id, service_id=None, framework=None):

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -765,21 +765,21 @@ class TestDataApiClient(object):
         assert rmock.called
         assert result == {"users": "result"}
 
-    def test_email_address_has_valid_buyer_domain_true(self, data_client, rmock):
+    def test_is_email_address_with_valid_buyer_domain_true(self, data_client, rmock):
         rmock.get(
             "http://baseurl/users/check-buyer-email?email_address=kev%40gov.uk",
             json={"valid": True},
             status_code=200)
-        result = data_client.email_address_has_valid_buyer_domain('kev@gov.uk')
+        result = data_client.is_email_address_with_valid_buyer_domain('kev@gov.uk')
         assert rmock.called
         assert result is True
 
-    def test_email_address_has_valid_buyer_domain_false(self, data_client, rmock):
+    def test_is_email_address_with_valid_buyer_domain_false(self, data_client, rmock):
         rmock.get(
             "http://baseurl/users/check-buyer-email?email_address=kev%40ymail.com",
             json={"valid": False},
             status_code=200)
-        result = data_client.email_address_has_valid_buyer_domain('kev@ymail.com')
+        result = data_client.is_email_address_with_valid_buyer_domain('kev@ymail.com')
         assert rmock.called
         assert result is False
 

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -765,6 +765,24 @@ class TestDataApiClient(object):
         assert rmock.called
         assert result == {"users": "result"}
 
+    def test_email_address_has_valid_buyer_domain_true(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/users/check-buyer-email?email_address=kev%40gov.uk",
+            json={"valid": True},
+            status_code=200)
+        result = data_client.email_address_has_valid_buyer_domain('kev@gov.uk')
+        assert rmock.called
+        assert result is True
+
+    def test_email_address_has_valid_buyer_domain_false(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/users/check-buyer-email?email_address=kev%40ymail.com",
+            json={"valid": False},
+            status_code=200)
+        result = data_client.email_address_has_valid_buyer_domain('kev@ymail.com')
+        assert rmock.called
+        assert result is False
+
     @staticmethod
     def user():
         return {'users': {


### PR DESCRIPTION
Client method for the new API endpoint here: https://github.com/alphagov/digitalmarketplace-api/pull/363