### PR TITLE
Add is_supplier_eligible_for_brief DataAPIClient method

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '3.4.1'
+__version__ = '3.5.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -556,6 +556,11 @@ class DataAPIClient(BaseAPIClient):
             user=user,
         )
 
+    def is_supplier_eligible_for_brief(self, supplier_id, brief_id):
+        return self._get(
+            "/suppliers/{}/briefs/{}".format(supplier_id, brief_id)
+        )['eligible']
+
     def create_brief_response(self, brief_id, supplier_id, data, user):
         data = dict(data, briefId=brief_id, supplierId=supplier_id)
         return self._post_with_updated_by(

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -557,9 +557,10 @@ class DataAPIClient(BaseAPIClient):
         )
 
     def is_supplier_eligible_for_brief(self, supplier_id, brief_id):
-        return self._get(
-            "/suppliers/{}/briefs/{}".format(supplier_id, brief_id)
-        )['eligible']
+        return len(self._get(
+            "/briefs/{}/services".format(brief_id),
+            params={"supplier_id": supplier_id}
+        )['services']) > 0
 
     def create_brief_response(self, brief_id, supplier_id, data, user):
         data = dict(data, briefId=brief_id, supplierId=supplier_id)

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1627,6 +1627,16 @@ class TestDataApiClient(object):
             'updated_by': 'user'
         }
 
+    def test_is_supplier_eligible_for_brief(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/suppliers/123/briefs/456",
+            json={"eligible": True},
+            status_code=200)
+
+        result = data_client.is_supplier_eligible_for_brief(123, 456)
+
+        assert result is True
+
     def test_create_brief_response(self, data_client, rmock):
         rmock.post(
             "http://baseurl/brief-responses",

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1629,13 +1629,23 @@ class TestDataApiClient(object):
 
     def test_is_supplier_eligible_for_brief(self, data_client, rmock):
         rmock.get(
-            "http://baseurl/suppliers/123/briefs/456",
-            json={"eligible": True},
+            "http://baseurl/briefs/456/services?supplier_id=123",
+            json={"services": ["one"]},
             status_code=200)
 
         result = data_client.is_supplier_eligible_for_brief(123, 456)
 
         assert result is True
+
+    def test_supplier_ineligible_for_brief(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/briefs/456/services?supplier_id=123",
+            json={"services": []},
+            status_code=200)
+
+        result = data_client.is_supplier_eligible_for_brief(123, 456)
+
+        assert result is False
 
     def test_create_brief_response(self, data_client, rmock):
         rmock.post(


### PR DESCRIPTION
### Add is_supplier_eligible_for_brief DataAPIClient method
Calls the related API endpoint and returns True if supplier is
eligible to respond to a brief or False otherwise.

Can be used to check whether "Apply" buttons should be displayed
or show an error page to the user, doesn't store anything in the
API.