### PR TITLE
Additional parameters for find_briefs method (status, lot and framework)

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '3.4.0'
+__version__ = '3.4.1'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -536,11 +536,18 @@ class DataAPIClient(BaseAPIClient):
         return self._get(
             "/briefs/{}".format(brief_id))
 
-    def find_briefs(self, user_id=None):
+    def find_briefs(self, user_id=None, status=None, framework=None, lot=None, page=None):
         return self._get(
             "/briefs",
-            params={"user_id": user_id}
+            params={"user_id": user_id,
+                    "framework": framework,
+                    "lot": lot,
+                    "status": status,
+                    "page": page
+                    }
         )
+
+    find_briefs_iter = make_iter_method('find_briefs', 'briefs', 'briefs')
 
     def delete_brief(self, brief_id, user):
         return self._delete_with_updated_by(

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1585,6 +1585,7 @@ class TestDataApiClient(object):
 
         result = data_client.find_briefs(user_id=123)
 
+        assert rmock.called
         assert result == {"briefs": []}
 
     def test_find_briefs_for_user(self, data_client, rmock):
@@ -1595,7 +1596,19 @@ class TestDataApiClient(object):
 
         result = data_client.find_briefs(user_id=123)
 
+        assert rmock.called
         assert result == {"briefs": []}
+
+    def test_find_briefs_by_lot_status_framework(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/briefs?status=live,closed&framework=digital-biscuits&lot=custard-creams",
+            json={"briefs": [{"biscuit": "tasty"}]},
+            status_code=200)
+
+        result = data_client.find_briefs(status="live,closed", framework="digital-biscuits", lot="custard-creams")
+
+        assert rmock.called
+        assert result == {"briefs": [{"biscuit": "tasty"}]}
 
     def test_delete_brief(self, data_client, rmock):
         rmock.delete(


### PR DESCRIPTION
Update to API client method now that the `find_briefs` endpoint can filter on status, lot and framework.

Also adds an iterator method for getting briefs, as brief fetches are paginated.