### PR TITLE
Add `frameworkName` to brief stub

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '3.5.0'
+__version__ = '3.5.1'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/api_stubs.py
+++ b/dmapiclient/api_stubs.py
@@ -34,12 +34,14 @@ def brief(status="draft",
           framework_slug="digital-outcomes-and-specialists",
           lot_slug="digital-specialists",
           user_id=123,
+          framework_name="Digital Outcomes and Specialists",
           clarification_questions=None):
     brief = {
         "briefs": {
             "id": 1234,
             "title": "I need a thing to do a thing",
             "frameworkSlug": framework_slug,
+            "frameworkName": framework_name,
             "lotSlug": lot_slug,
             "status": status,
             "users": [{"active": True,

--- a/tests/test_api_stubs.py
+++ b/tests/test_api_stubs.py
@@ -40,6 +40,7 @@ def test_brief():
             "id": 1234,
             "title": "I need a thing to do a thing",
             "frameworkSlug": "digital-outcomes-and-specialists",
+            "frameworkName": "Digital Outcomes and Specialists",
             "lotSlug": "digital-specialists",
             "status": "draft",
             "users": [{"active": True,
@@ -53,12 +54,17 @@ def test_brief():
         }
     }
 
-    assert api_stubs.brief(status='live', framework_slug='a-framework-slug', lot_slug='a-lot-slug', user_id=234) \
+    assert api_stubs.brief(
+        status='live',
+        framework_slug='a-framework-slug',
+        lot_slug='a-lot-slug', user_id=234,
+        framework_name='A Framework Name') \
         == {
         "briefs": {
             "id": 1234,
             "title": "I need a thing to do a thing",
             "frameworkSlug": "a-framework-slug",
+            "frameworkName": "A Framework Name",
             "lotSlug": "a-lot-slug",
             "status": "live",
             "users": [{"active": True,
@@ -79,6 +85,7 @@ def test_brief():
             "id": 1234,
             "title": "I need a thing to do a thing",
             "frameworkSlug": "digital-outcomes-and-specialists",
+            "frameworkName": "Digital Outcomes and Specialists",
             "lotSlug": "digital-specialists",
             "status": "draft",
             "users": [{"active": True,


### PR DESCRIPTION
Helpful for displaying an error message when a supplier is not eligible for a brief (currently being worked on [here](https://github.com/alphagov/digitalmarketplace-supplier-frontend/tree/ensure-eligible-suppliers)).