### PR TITLE
Add audit event for create_framework

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '3.6.0'
+__version__ = '3.7.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/audit.py
+++ b/dmapiclient/audit.py
@@ -41,6 +41,7 @@ class AuditTypes(Enum):
     answer_selection_questions = "answer_selection_questions"
 
     # Framework lifecycle
+    create_framework = "create_framework"
     framework_update = "framework_update"
 
     # Admin actions


### PR DESCRIPTION
I have chosen to go with `create_framework` rather than `framework_create` because that is how most of the other audit events are named.