### PR TITLE
Added and updated methods for signerDetails and countersigned field for framework interest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Records breaking changes from major version bumps
 
+## 4.0.0
+
+PR: [#26](https://github.com/alphagov/digitalmarketplace-apiclient/pull/26)
+
+### What changed
+
+Removed the `unset_framework_agreement_returned` method.
+
+This shouldn't require any changes as this method is only used in at most one old script and should 
+never need to be used again.
+
 ## 3.0.0
 
 PR: [#14](https://github.com/alphagov/digitalmarketplace-apiclient/pull/14)

--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '3.8.0'
+__version__ = '3.9.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '3.9.0'
+__version__ = '4.0.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -195,34 +195,12 @@ class DataAPIClient(BaseAPIClient):
             user=user,
         )
 
-    def unset_framework_agreement_returned(self, supplier_id, framework_slug, user):
-        return self._post_with_updated_by(
-            "/suppliers/{}/frameworks/{}".format(
-                supplier_id, framework_slug),
-            data={
-                "frameworkInterest": {
-                    "agreementReturned": False,
-                },
-            },
-            user=user,
-        )
-
     def register_framework_agreement_countersigned(self, supplier_id, framework_slug, user):
         return self._post_with_updated_by(
             "/suppliers/{}/frameworks/{}".format(
                 supplier_id, framework_slug),
             data={
                 "frameworkInterest": {"countersigned": True},
-            },
-            user=user,
-        )
-
-    def unset_framework_agreement_countersigned(self, supplier_id, framework_slug, user):
-        return self._post_with_updated_by(
-            "/suppliers/{}/frameworks/{}".format(
-                supplier_id, framework_slug),
-            data={
-                "frameworkInterest": {"countersigned": False},
             },
             user=user,
         )

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -181,13 +181,17 @@ class DataAPIClient(BaseAPIClient):
             user=user,
         )
 
-    def register_framework_agreement_returned(self, supplier_id, framework_slug, user):
+    def register_framework_agreement_returned(self, supplier_id, framework_slug, user, signer_details=None):
+        framework_interest_dict = {
+            "agreementReturned": True,
+        }
+        if signer_details is not None:
+            framework_interest_dict['signerDetails'] = signer_details
+
         return self._post_with_updated_by(
             "/suppliers/{}/frameworks/{}".format(
                 supplier_id, framework_slug),
-            data={
-                "frameworkInterest": {"agreementReturned": True},
-            },
+            data={"frameworkInterest": framework_interest_dict},
             user=user,
         )
 
@@ -196,7 +200,29 @@ class DataAPIClient(BaseAPIClient):
             "/suppliers/{}/frameworks/{}".format(
                 supplier_id, framework_slug),
             data={
-                "frameworkInterest": {"agreementReturned": False},
+                "frameworkInterest": {
+                    "agreementReturned": False,
+                },
+            },
+            user=user,
+        )
+
+    def register_framework_agreement_countersigned(self, supplier_id, framework_slug, user):
+        return self._post_with_updated_by(
+            "/suppliers/{}/frameworks/{}".format(
+                supplier_id, framework_slug),
+            data={
+                "frameworkInterest": {"countersigned": True},
+            },
+            user=user,
+        )
+
+    def unset_framework_agreement_countersigned(self, supplier_id, framework_slug, user):
+        return self._post_with_updated_by(
+            "/suppliers/{}/frameworks/{}".format(
+                supplier_id, framework_slug),
+            data={
+                "frameworkInterest": {"countersigned": False},
             },
             user=user,
         )

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1026,18 +1026,57 @@ class TestDataApiClient(object):
             'updated_by': 'user'
         }
 
-    def test_register_framework_agreement_returned(self, data_client, rmock):
+    def test_register_framework_agreement_returned_with_signer_details(self, data_client, rmock):
         rmock.post(
             "http://baseurl/suppliers/123/frameworks/g-cloud-7",
-            json={"frameworkInterest": {"agreementReturned": True}},
+            json={
+                'frameworkInterest': {
+                    'agreementReturned': True,
+                    'signerDetails': {'some': 'details'},
+                },
+            },
+            status_code=200)
+
+        result = data_client.register_framework_agreement_returned(
+            123, 'g-cloud-7', "user", signer_details={'some': 'details'}
+        )
+        assert result == {
+            'frameworkInterest': {
+                'agreementReturned': True,
+                'signerDetails': {'some': 'details'},
+            },
+        }
+        assert rmock.called
+        assert rmock.request_history[0].json() == {
+            'frameworkInterest': {
+                    'agreementReturned': True,
+                    'signerDetails': {'some': 'details'},
+                },
+            'updated_by': 'user',
+        }
+
+    def test_register_framework_agreement_returned_without_signer_details(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/suppliers/123/frameworks/g-cloud-7",
+            json={
+                'frameworkInterest': {
+                    'agreementReturned': True,
+                },
+            },
             status_code=200)
 
         result = data_client.register_framework_agreement_returned(123, 'g-cloud-7', "user")
-        assert result == {"frameworkInterest": {"agreementReturned": True}}
+        assert result == {
+            'frameworkInterest': {
+                'agreementReturned': True,
+            },
+        }
         assert rmock.called
         assert rmock.request_history[0].json() == {
-            'frameworkInterest': {'agreementReturned': True},
-            'updated_by': 'user'
+            'frameworkInterest': {
+                    'agreementReturned': True,
+                },
+            'updated_by': 'user',
         }
 
     def test_unset_framework_agreement_returned(self, data_client, rmock):
@@ -1051,6 +1090,34 @@ class TestDataApiClient(object):
         assert rmock.called
         assert rmock.request_history[0].json() == {
             'frameworkInterest': {'agreementReturned': False},
+            'updated_by': 'user'
+        }
+
+    def test_register_framework_agreement_countersigned(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/suppliers/123/frameworks/g-cloud-7",
+            json={"frameworkInterest": {"countersigned": True}},
+            status_code=200)
+
+        result = data_client.register_framework_agreement_countersigned(123, 'g-cloud-7', "user")
+        assert result == {"frameworkInterest": {"countersigned": True}}
+        assert rmock.called
+        assert rmock.request_history[0].json() == {
+            'frameworkInterest': {'countersigned': True},
+            'updated_by': 'user'
+        }
+
+    def test_unset_framework_agreement_countersigned(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/suppliers/123/frameworks/g-cloud-7",
+            json={"frameworkInterest": {"countersigned": False}},
+            status_code=200)
+
+        result = data_client.unset_framework_agreement_countersigned(123, 'g-cloud-7', "user")
+        assert result == {"frameworkInterest": {"countersigned": False}}
+        assert rmock.called
+        assert rmock.request_history[0].json() == {
+            'frameworkInterest': {'countersigned': False},
             'updated_by': 'user'
         }
 

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1079,20 +1079,6 @@ class TestDataApiClient(object):
             'updated_by': 'user',
         }
 
-    def test_unset_framework_agreement_returned(self, data_client, rmock):
-        rmock.post(
-            "http://baseurl/suppliers/123/frameworks/g-cloud-7",
-            json={"frameworkInterest": {"agreementReturned": False}},
-            status_code=200)
-
-        result = data_client.unset_framework_agreement_returned(123, 'g-cloud-7', "user")
-        assert result == {"frameworkInterest": {"agreementReturned": False}}
-        assert rmock.called
-        assert rmock.request_history[0].json() == {
-            'frameworkInterest': {'agreementReturned': False},
-            'updated_by': 'user'
-        }
-
     def test_register_framework_agreement_countersigned(self, data_client, rmock):
         rmock.post(
             "http://baseurl/suppliers/123/frameworks/g-cloud-7",
@@ -1104,20 +1090,6 @@ class TestDataApiClient(object):
         assert rmock.called
         assert rmock.request_history[0].json() == {
             'frameworkInterest': {'countersigned': True},
-            'updated_by': 'user'
-        }
-
-    def test_unset_framework_agreement_countersigned(self, data_client, rmock):
-        rmock.post(
-            "http://baseurl/suppliers/123/frameworks/g-cloud-7",
-            json={"frameworkInterest": {"countersigned": False}},
-            status_code=200)
-
-        result = data_client.unset_framework_agreement_countersigned(123, 'g-cloud-7', "user")
-        assert result == {"frameworkInterest": {"countersigned": False}}
-        assert rmock.called
-        assert rmock.request_history[0].json() == {
-            'frameworkInterest': {'countersigned': False},
             'updated_by': 'user'
         }
 


### PR DESCRIPTION
Updated register_framework_agreement_returned method to take an optional signer_details parameter. If parameter is provided then signer_details will be set/updated. If parameter is not provided then signer_details is left unchanged. Tests added for both of these cases.

Added register_framework_agreement_countersigned method with corresponding test.

We decided not to alter the signer_details field by default when calling `register_framework_agreement_returned` method because silently overwriting it by default would be surprising behaviour.

Removed previous unset_framework_agreement_returned method which is no longer being used and therefore not needed. Therefore bumped version to 4.0.0