### PR TITLE
`signer_details` -> `agreement_details` + un-remove unsetting framework agreements

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '4.0.0'
+__version__ = '4.1.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -181,12 +181,12 @@ class DataAPIClient(BaseAPIClient):
             user=user,
         )
 
-    def register_framework_agreement_returned(self, supplier_id, framework_slug, user, signer_details=None):
+    def register_framework_agreement_returned(self, supplier_id, framework_slug, user, agreement_details=None):
         framework_interest_dict = {
             "agreementReturned": True,
         }
-        if signer_details is not None:
-            framework_interest_dict['signerDetails'] = signer_details
+        if agreement_details is not None:
+            framework_interest_dict['agreementDetails'] = agreement_details
 
         return self._post_with_updated_by(
             "/suppliers/{}/frameworks/{}".format(

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -195,6 +195,18 @@ class DataAPIClient(BaseAPIClient):
             user=user,
         )
 
+    def unset_framework_agreement_returned(self, supplier_id, framework_slug, user):
+        return self._post_with_updated_by(
+            "/suppliers/{}/frameworks/{}".format(
+                supplier_id, framework_slug),
+            data={
+                "frameworkInterest": {
+                    "agreementReturned": False,
+                },
+            },
+            user=user,
+        )
+
     def register_framework_agreement_countersigned(self, supplier_id, framework_slug, user):
         return self._post_with_updated_by(
             "/suppliers/{}/frameworks/{}".format(

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1079,6 +1079,20 @@ class TestDataApiClient(object):
             'updated_by': 'user',
         }
 
+    def test_unset_framework_agreement_returned(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/suppliers/123/frameworks/g-cloud-7",
+            json={"frameworkInterest": {"agreementReturned": False}},
+            status_code=200)
+
+        result = data_client.unset_framework_agreement_returned(123, 'g-cloud-7', "user")
+        assert result == {"frameworkInterest": {"agreementReturned": False}}
+        assert rmock.called
+        assert rmock.request_history[0].json() == {
+            'frameworkInterest': {'agreementReturned': False},
+            'updated_by': 'user'
+        }
+
     def test_register_framework_agreement_countersigned(self, data_client, rmock):
         rmock.post(
             "http://baseurl/suppliers/123/frameworks/g-cloud-7",

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1026,36 +1026,36 @@ class TestDataApiClient(object):
             'updated_by': 'user'
         }
 
-    def test_register_framework_agreement_returned_with_signer_details(self, data_client, rmock):
+    def test_register_framework_agreement_returned_with_agreement_details(self, data_client, rmock):
         rmock.post(
             "http://baseurl/suppliers/123/frameworks/g-cloud-7",
             json={
                 'frameworkInterest': {
                     'agreementReturned': True,
-                    'signerDetails': {'some': 'details'},
+                    'agreementDetails': {'some': 'details'},
                 },
             },
             status_code=200)
 
         result = data_client.register_framework_agreement_returned(
-            123, 'g-cloud-7', "user", signer_details={'some': 'details'}
+            123, 'g-cloud-7', "user", agreement_details={'some': 'details'}
         )
         assert result == {
             'frameworkInterest': {
                 'agreementReturned': True,
-                'signerDetails': {'some': 'details'},
+                'agreementDetails': {'some': 'details'},
             },
         }
         assert rmock.called
         assert rmock.request_history[0].json() == {
             'frameworkInterest': {
                     'agreementReturned': True,
-                    'signerDetails': {'some': 'details'},
+                    'agreementDetails': {'some': 'details'},
                 },
             'updated_by': 'user',
         }
 
-    def test_register_framework_agreement_returned_without_signer_details(self, data_client, rmock):
+    def test_register_framework_agreement_returned_without_agreement_details(self, data_client, rmock):
         rmock.post(
             "http://baseurl/suppliers/123/frameworks/g-cloud-7",
             json={


### PR DESCRIPTION
####  Rename `signer_details` to `agreement_details`

We are expanding the scope of what the `*_details` JSON field will store to do with signing framework agreements.  (For example, not all stored values will be about the supplier who signs it -- we are also planning to save the name/role of the countersigner.)

With this in mind, we are generalising the name of the column in the database.  This is easy to do now because no one is using it yet.

#### Add back a way to unset framework agreements
We used them for DOS, so @allait says keep them in.