### PR TITLE
Return framework agreement and update `agreementDetails`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 Records breaking changes from major version bumps
 
+## 5.0.0
+
+PR: [#28](https://github.com/alphagov/digitalmarketplace-apiclient/pull/28)
+
+### What changed
+
+Changed `register_framework_agreement_returned` from taking an optional `agreement_details`
+parameter to taking an optional `uploader_user_id` parameter. This is because when returning an
+agreement (that has a framework agreement version), we expect only an `uploader_user_id` instead
+of a flexible dictionary and have made this method stricter to enforce/strongly encourage this.
+
+At the moment, this should cause no actual breaks in our applications as the `agreement_details`
+parameter is not yet being used.
+
 ## 4.0.0
 
 PR: [#26](https://github.com/alphagov/digitalmarketplace-apiclient/pull/26)
@@ -10,7 +24,7 @@ PR: [#26](https://github.com/alphagov/digitalmarketplace-apiclient/pull/26)
 
 Removed the `unset_framework_agreement_returned` method.
 
-This shouldn't require any changes as this method is only used in at most one old script and should 
+This shouldn't require any changes as this method is only used in at most one old script and should
 never need to be used again.
 
 ## 3.0.0

--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '4.1.0'
+__version__ = '5.0.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -181,12 +181,12 @@ class DataAPIClient(BaseAPIClient):
             user=user,
         )
 
-    def register_framework_agreement_returned(self, supplier_id, framework_slug, user, agreement_details=None):
+    def register_framework_agreement_returned(self, supplier_id, framework_slug, user, uploader_user_id=None):
         framework_interest_dict = {
             "agreementReturned": True,
         }
-        if agreement_details is not None:
-            framework_interest_dict['agreementDetails'] = agreement_details
+        if uploader_user_id is not None:
+            framework_interest_dict['agreementDetails'] = {'uploaderUserId': uploader_user_id}
 
         return self._post_with_updated_by(
             "/suppliers/{}/frameworks/{}".format(
@@ -202,6 +202,18 @@ class DataAPIClient(BaseAPIClient):
             data={
                 "frameworkInterest": {
                     "agreementReturned": False,
+                },
+            },
+            user=user,
+        )
+
+    def update_supplier_framework_agreement_details(self, supplier_id, framework_slug, agreement_details, user):
+        return self._post_with_updated_by(
+            "/suppliers/{}/frameworks/{}".format(
+                supplier_id, framework_slug),
+            data={
+                "frameworkInterest": {
+                    "agreementDetails": agreement_details
                 },
             },
             user=user,

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1026,36 +1026,36 @@ class TestDataApiClient(object):
             'updated_by': 'user'
         }
 
-    def test_register_framework_agreement_returned_with_agreement_details(self, data_client, rmock):
+    def test_register_framework_agreement_returned_with_uploader_user_id(self, data_client, rmock):
         rmock.post(
-            "http://baseurl/suppliers/123/frameworks/g-cloud-7",
+            "http://baseurl/suppliers/123/frameworks/g-cloud-8",
             json={
                 'frameworkInterest': {
                     'agreementReturned': True,
-                    'agreementDetails': {'some': 'details'},
+                    'agreementDetails': {'uploaderUserId': 10},
                 },
             },
             status_code=200)
 
         result = data_client.register_framework_agreement_returned(
-            123, 'g-cloud-7', "user", agreement_details={'some': 'details'}
+            123, 'g-cloud-8', "user", 10
         )
         assert result == {
             'frameworkInterest': {
                 'agreementReturned': True,
-                'agreementDetails': {'some': 'details'},
+                'agreementDetails': {'uploaderUserId': 10},
             },
         }
         assert rmock.called
         assert rmock.request_history[0].json() == {
             'frameworkInterest': {
                     'agreementReturned': True,
-                    'agreementDetails': {'some': 'details'},
+                    'agreementDetails': {'uploaderUserId': 10},
                 },
             'updated_by': 'user',
         }
 
-    def test_register_framework_agreement_returned_without_agreement_details(self, data_client, rmock):
+    def test_register_framework_agreement_returned_without_uploader_user_id(self, data_client, rmock):
         rmock.post(
             "http://baseurl/suppliers/123/frameworks/g-cloud-7",
             json={
@@ -1091,6 +1091,32 @@ class TestDataApiClient(object):
         assert rmock.request_history[0].json() == {
             'frameworkInterest': {'agreementReturned': False},
             'updated_by': 'user'
+        }
+
+    def test_update_supplier_framework_agreement_details(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/suppliers/123/frameworks/g-cloud-8",
+            json={
+                'frameworkInterest': {
+                    'agreementDetails': {'signerName': 'name'},
+                },
+            },
+            status_code=200)
+
+        result = data_client.update_supplier_framework_agreement_details(
+            123, 'g-cloud-8', {'signerName': 'name'}, "user"
+        )
+        assert result == {
+            'frameworkInterest': {
+                'agreementDetails': {'signerName': 'name'}
+            },
+        }
+        assert rmock.called
+        assert rmock.request_history[0].json() == {
+            'frameworkInterest': {
+                    'agreementDetails': {'signerName': 'name'}
+                },
+            'updated_by': 'user',
         }
 
     def test_register_framework_agreement_countersigned(self, data_client, rmock):


### PR DESCRIPTION
Added `update_supplier_framework_agreement_details` function to set and update keys in `agreementDetails`

Changed `register_framework_agreement_returned` from taking an optional `agreement_details` parameter to taking an optional `uploader_user_id` paramater. This is because when returning an agreement (that has a framework agreement version), we expect only an `uploader_user_id` instead 
of a flexible dictionary and have made this method stricter to enforce/strongly encourage this. There should currently be no usage of this in our applications as this feature is not yet released and is being tweaked since the previous related [pull request](https://github.com/alphagov/digitalmarketplace-apiclient/pull/27).

Due to the above breaking change, we bump to 5.0.0.

This PR relies on the following API [pull request](https://github.com/alphagov/digitalmarketplace-api/pull/416).