### PR TITLE
Add audit event types for submitting signed framework agreement

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '5.0.0'
+__version__ = '5.1.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/audit.py
+++ b/dmapiclient/audit.py
@@ -40,6 +40,9 @@ class AuditTypes(Enum):
     send_application_question = "send_application_question"
     answer_selection_questions = "answer_selection_questions"
 
+    # Framework agreements
+    upload_signed_agreement = "upload_signed_agreement"
+
     # Framework lifecycle
     create_framework = "create_framework"
     framework_update = "framework_update"


### PR DESCRIPTION
Events created  when the user uploads a new agreement file (event created by the supplier frontend), updates agreement details (like signer details) or sets "agreement returned".