### PR TITLE
Specialist briefs can be open for 1 or 2 weeks.

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '5.1.0'
+__version__ = '5.2.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -565,14 +565,15 @@ class DataAPIClient(BaseAPIClient):
         return self._get(
             "/briefs/{}".format(brief_id))
 
-    def find_briefs(self, user_id=None, status=None, framework=None, lot=None, page=None):
+    def find_briefs(self, user_id=None, status=None, framework=None, lot=None, page=None, human=None):
         return self._get(
             "/briefs",
             params={"user_id": user_id,
                     "framework": framework,
                     "lot": lot,
                     "status": status,
-                    "page": page
+                    "page": page,
+                    "human": human
                     }
         )
 

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1678,13 +1678,13 @@ class TestDataApiClient(object):
         assert rmock.called
         assert result == {"briefs": []}
 
-    def test_find_briefs_by_lot_status_framework(self, data_client, rmock):
+    def test_find_briefs_by_lot_status_framework_and_human_readable(self, data_client, rmock):
         rmock.get(
-            "http://baseurl/briefs?status=live,closed&framework=digital-biscuits&lot=custard-creams",
+            "http://baseurl/briefs?status=live,closed&framework=digital-biscuits&lot=custard-creams&human=true",
             json={"briefs": [{"biscuit": "tasty"}]},
             status_code=200)
 
-        result = data_client.find_briefs(status="live,closed", framework="digital-biscuits", lot="custard-creams")
+        result = data_client.find_briefs(status="live,closed", framework="digital-biscuits", lot="custard-creams", human=True)
 
         assert rmock.called
         assert result == {"briefs": [{"biscuit": "tasty"}]}

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1684,7 +1684,8 @@ class TestDataApiClient(object):
             json={"briefs": [{"biscuit": "tasty"}]},
             status_code=200)
 
-        result = data_client.find_briefs(status="live,closed", framework="digital-biscuits", lot="custard-creams", human=True)
+        result = data_client.find_briefs(status="live,closed", framework="digital-biscuits", lot="custard-creams",
+                                         human=True)
 
         assert rmock.called
         assert result == {"briefs": [{"biscuit": "tasty"}]}


### PR DESCRIPTION
For [this ](https://www.pivotaltracker.com/story/show/123706751) story on Pivotal.

This PR adds a new flag to the find_briefs route. This is invoked by the buyer frontend when getting a list of briefs for the catalogue.

The human flag is passed to the API to make it return a list of briefs sorted in a human readable way. PR on the API can be found [here](https://github.com/alphagov/digitalmarketplace-api/pull/422)