### PR TITLE
Remove `update_brief_status' method and add `publish_brief` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 Records breaking changes from major version bumps
 
+## 6.0.0
+
+PR: [#31](https://github.com/alphagov/digitalmarketplace-apiclient/pull/31)
+
+### What changed
+
+Removed `update_brief_status` method.
+
+This functionality has been removed and calls to publish a brief (i.e. change it's status from
+'draft' to 'live') should now use the `publish_brief` method. There should no other current
+uses of the `update_brief_status` in our apps that set a status to something other than 'live'.
+
+### Example app change
+
+Old
+```
+api_client.update_brief_status(brief_id, 'live', user)
+```
+
+New
+```
+api_client.publish_brief(brief_id, user)
+
+
 ## 5.0.0
 
 PR: [#28](https://github.com/alphagov/digitalmarketplace-apiclient/pull/28)

--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '5.2.0'
+__version__ = '6.0.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -552,12 +552,10 @@ class DataAPIClient(BaseAPIClient):
             user=updated_by,
         )
 
-    def update_brief_status(self, brief_id, status, user):
-        return self._put_with_updated_by(
-            "/briefs/{}/status".format(brief_id),
-            data={
-                "briefs": {"status": status},
-            },
+    def publish_brief(self, brief_id, user):
+        return self._post_with_updated_by(
+            "/briefs/{}/publish".format(brief_id),
+            data={},
             user=user,
         )
 

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1631,18 +1631,17 @@ class TestDataApiClient(object):
             "updated_by": "user@email.com"
         }
 
-    def test_update_brief_status(self, data_client, rmock):
-        rmock.put(
-            "http://baseurl/briefs/123/status",
+    def test_publish_brief(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/briefs/123/publish",
             json={"briefs": "result"},
             status_code=200,
         )
 
-        result = data_client.update_brief_status(123, "published", "user@email.com")
+        result = data_client.publish_brief(123, "user@email.com")
 
         assert result == {"briefs": "result"}
         assert rmock.last_request.json() == {
-            "briefs": {"status": "published"},
             "updated_by": "user@email.com"
         }
 


### PR DESCRIPTION
- Relies on [the API pull request](url) to be merged first.

- Breaking change, bumps version to 6.0.0

- Functionality to update a brief's status to a requested value has been deprecated in the API. A `publish` route has been added to the API, which updates the brief's status from 'draft' to 'live', that should be used instead. We have therefore removed the clients `update_brief_status` method and added a `publish_brief` method to enable this transition.

- Note, whilst a `withdraw` route has also been added to the API, we are not yet adding that to the client as this route should not be used in any of our front end apps. Withdrawing functionality is not yet being given to users and instead developers will directly curl the API to withdraw an opportunity.