### PR TITLE
Add method to call /buyer/briefs on api

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '6.0.0'
+__version__ = '6.1.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -358,6 +358,11 @@ class DataAPIClient(BaseAPIClient):
             "/users/export/{}".format(framework_slug)
         )
 
+    def export_buyers_with_briefs(self):
+        return self._get(
+            "/buyers/briefs"
+        )
+
     def is_email_address_with_valid_buyer_domain(self, email_address):
         return self._get(
             "/users/check-buyer-email", params={'email_address': email_address}

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -765,6 +765,15 @@ class TestDataApiClient(object):
         assert rmock.called
         assert result == {"users": "result"}
 
+    def test_can_export_buyers_with_briefs(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/buyers/briefs",
+            json={"buyers": "result"},
+            status_code=200)
+        result = data_client.export_buyers_with_briefs()
+        assert rmock.called
+        assert result == {"buyers": "result"}
+
     def test_is_email_address_with_valid_buyer_domain_true(self, data_client, rmock):
         rmock.get(
             "http://baseurl/users/check-buyer-email?email_address=kev%40gov.uk",


### PR DESCRIPTION
For [this](https://www.pivotaltracker.com/story/show/124104161) story on Pivotal.

This has been created for calling from the admin frontend, to allow for downloading of a csv containing buyers info and their briefs.

PR for the new endpoint on the api is [here](https://github.com/alphagov/digitalmarketplace-api/pull/430)