### PR TITLE
Add only_buyers and with_users to /users and /briefs respectively

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '6.1.0'
+__version__ = '6.2.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -247,10 +247,15 @@ class DataAPIClient(BaseAPIClient):
                 "users": user,
             })
 
-    def find_users(self, supplier_id=None, page=None):
+    def find_users(self, supplier_id=None, page=None, role=None):
         params = {}
+        if supplier_id is not None and role is not None:
+            raise ValueError(
+                "Cannot get users by both supplier_id and role")
         if supplier_id is not None:
             params['supplier_id'] = supplier_id
+        if role is not None:
+            params['role'] = role
         if page is not None:
             params['page'] = page
         return self._get("/users", params=params)
@@ -563,7 +568,7 @@ class DataAPIClient(BaseAPIClient):
         return self._get(
             "/briefs/{}".format(brief_id))
 
-    def find_briefs(self, user_id=None, status=None, framework=None, lot=None, page=None, human=None):
+    def find_briefs(self, user_id=None, status=None, framework=None, lot=None, page=None, human=None, with_users=None):
         return self._get(
             "/briefs",
             params={"user_id": user_id,
@@ -571,7 +576,8 @@ class DataAPIClient(BaseAPIClient):
                     "lot": lot,
                     "status": status,
                     "page": page,
-                    "human": human
+                    "human": human,
+                    "with_users": with_users
                     }
         )
 

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -504,6 +504,20 @@ class TestDataApiClient(object):
 
         assert user == self.user()
 
+    def test_find_users_not_possible_with_supplier_id_and_role(self, data_client, rmock):
+        with pytest.raises(ValueError):
+            data_client.find_users(supplier_id=123, role='buyer')
+
+    def test_find_users_by_role(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/users?role=buyer",
+            json=self.user(),
+            status_code=200)
+
+        user = data_client.find_users(role='buyer')
+
+        assert user == self.user()
+
     def test_find_users_by_page(self, data_client, rmock):
         rmock.get(
             "http://baseurl/users?page=12",
@@ -1049,9 +1063,9 @@ class TestDataApiClient(object):
         assert rmock.called
         assert rmock.request_history[0].json() == {
             'frameworkInterest': {
-                    'agreementReturned': True,
-                    'agreementDetails': {'uploaderUserId': 10},
-                },
+                'agreementReturned': True,
+                'agreementDetails': {'uploaderUserId': 10},
+            },
             'updated_by': 'user',
         }
 
@@ -1074,8 +1088,8 @@ class TestDataApiClient(object):
         assert rmock.called
         assert rmock.request_history[0].json() == {
             'frameworkInterest': {
-                    'agreementReturned': True,
-                },
+                'agreementReturned': True,
+            },
             'updated_by': 'user',
         }
 
@@ -1114,8 +1128,8 @@ class TestDataApiClient(object):
         assert rmock.called
         assert rmock.request_history[0].json() == {
             'frameworkInterest': {
-                    'agreementDetails': {'signerName': 'name'}
-                },
+                'agreementDetails': {'signerName': 'name'}
+            },
             'updated_by': 'user',
         }
 
@@ -1685,6 +1699,17 @@ class TestDataApiClient(object):
 
         result = data_client.find_briefs(status="live,closed", framework="digital-biscuits", lot="custard-creams",
                                          human=True)
+
+        assert rmock.called
+        assert result == {"briefs": [{"biscuit": "tasty"}]}
+
+    def test_find_briefs_with_users(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/briefs?with_users=True",
+            json={"briefs": [{"biscuit": "tasty"}]},
+            status_code=200)
+
+        result = data_client.find_briefs(with_users=True)
 
         assert rmock.called
         assert result == {"briefs": [{"biscuit": "tasty"}]}


### PR DESCRIPTION
Part of [this](https://www.pivotaltracker.com/story/show/124104161) Pivotal story.

It replaces [this](https://github.com/alphagov/digitalmarketplace-apiclient/pull/32) PR from a previous version.

These updates are to allow the admin app to request briefs from the API with their user information, and to request users are filtered by `role == 'buyer'`.