### PR TITLE
Preserve base URL host and scheme when requesting next API page

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '6.3.2'
+__version__ = '6.3.3'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -166,6 +166,16 @@ class TestBaseApiClient(object):
 
         assert rmock.last_request.headers.get("User-Agent").startswith("DM-API-Client/")
 
+    def test_request_always_uses_base_url_scheme(self, base_client, rmock):
+        rmock.request(
+            "GET",
+            "http://baseurl/path/",
+            json={},
+            status_code=200)
+
+        base_client._request('GET', 'https://host/path/')
+        assert rmock.called
+
 
 class TestSearchApiClient(object):
     def test_init_app_sets_attributes(self, search_client):


### PR DESCRIPTION
API responses always return next/prev links with https:// since API doesn't know if the request was made internally or through nginx. This means that apps using `_iter` methods will try to request `page=2` from `https://...`, which doesn't work when accessing the API apache server directly.

To fix this we make `_request` always use `base_url` host and scheme.