### PR TITLE
Add agreement-related audit events

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '6.3.3'
+__version__ = '6.4.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/audit.py
+++ b/dmapiclient/audit.py
@@ -42,15 +42,19 @@ class AuditTypes(Enum):
     agree_framework_variation = "agree_framework_variation"
 
     # Framework agreements
+    create_agreement = "create_agreement"
+    update_agreement = "update_agreement"
     upload_signed_agreement = "upload_signed_agreement"
+    sign_agreement = "sign_agreement"
+    upload_countersigned_agreement = "upload_countersigned_agreement"
+    countersign_agreement = "countersign_agreement"
+    delete_countersigned_agreement = "delete_countersigned_agreement"
 
     # Framework lifecycle
     create_framework = "create_framework"
     framework_update = "framework_update"
 
     # Admin actions
-    upload_countersigned_agreement = "upload_countersigned_agreement"
-    delete_countersigned_agreement = "delete_countersigned_agreement"
     snapshot_framework_stats = "snapshot_framework_stats"
 
     @staticmethod


### PR DESCRIPTION
We need audit events to track creating, updating, signing, and countersigning an agreement.