### PR TITLE
Temporary route to support countersigning framework agreement script

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '6.5.0'
+__version__ = '6.6.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -653,3 +653,19 @@ class DataAPIClient(BaseAPIClient):
             },
             user=user,
         )
+
+    def temp_script_countersign_agreement(
+        self, framework_agreement_id, countersigned_path, countersigned_at, user
+    ):
+        # Temporary route only to be used for a one off script
+        # Afterwards this route can be deleted
+        return self._post_with_updated_by(
+            "/agreements/{}/countersign-script".format(framework_agreement_id),
+            data={
+                "agreement": {
+                    "countersignedAgreementPath": countersigned_path,
+                    "countersignedAgreementReturnedAt": countersigned_at
+                }
+            },
+            user=user,
+        )

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1864,6 +1864,29 @@ class TestDataApiClient(object):
             "updated_by": "user@example.com",
         }
 
+    def test_temp_script_countersign_agreement(self, data_client, rmock):
+        # Test for temporary route. Can be deleted after script is run.
+        rmock.post(
+            "http://baseurl/agreements/12345/countersign-script",
+            json={"agreement": {'details': 'here'}},
+            status_code=200)
+
+        result = data_client.temp_script_countersign_agreement(
+            12345,
+            "example/path/file.pdf",
+            "2016-11-01T00:00:00.000000Z",
+            "user@example.com"
+        )
+
+        assert result == {"agreement": {'details': 'here'}}
+        assert rmock.last_request.json() == {
+            "agreement": {
+                "countersignedAgreementPath": "example/path/file.pdf",
+                "countersignedAgreementReturnedAt": "2016-11-01T00:00:00.000000Z"
+            },
+            "updated_by": "user@example.com",
+        }
+
 
 class TestDataAPIClientIterMethods(object):
     def _test_find_iter(self, data_client, rmock, method_name, model_name, url_path):


### PR DESCRIPTION
To support temporary API route from [this pull request](https://github.com/alphagov/digitalmarketplace-api/pull/461). Can be removed after one off framework agreement countersigning script has been run.