### PR TITLE
Add route for putting agreements on hold

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '6.6.0'
+__version__ = '6.7.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -669,3 +669,10 @@ class DataAPIClient(BaseAPIClient):
             },
             user=user,
         )
+
+    def put_signed_agreement_on_hold(self, framework_agreement_id, user):
+        return self._post_with_updated_by(
+            "/agreements/{}/on-hold".format(framework_agreement_id),
+            data={},
+            user=user
+        )

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1203,6 +1203,18 @@ class TestDataApiClient(object):
         assert result == {'supplierFrameworks': [{"agreementReturned": False}, {"agreementReturned": True}]}
         assert rmock.called
 
+    def test_put_signed_agreement_on_hold(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/agreements/101/on-hold",
+            json={},
+            status_code=200
+        )
+
+        data_client.put_signed_agreement_on_hold(101, 'Chris')
+
+        assert rmock.call_count == 1
+        assert rmock.last_request.json() == {'updated_by': 'Chris'}
+
     def test_find_draft_services(self, data_client, rmock):
         rmock.get(
             "http://baseurl/draft-services?supplier_id=2",


### PR DESCRIPTION
Part of this [story in Pivotal](https://www.pivotaltracker.com/story/show/128842457).

When a CCS admin hits the button in the admin app to put an agreement on hold, the app needs to hit the api to record this change. This route on the apiclient hits the endpoint on the api that does this, passing the current user with it for an audit event.