### PR TITLE
Remove temporary route to set countersigned timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 Records breaking changes from major version bumps
 
+## 7.0.0
+
+PR: [#31](https://github.com/alphagov/digitalmarketplace-apiclient/pull/45)
+
+### What changed
+
+Removed `temp_script_countersign_agreement` method.
+
+This route, which allowed the timestamp for countersigning an agreement to be arbitrarily set, only existed for a
+one-off script that has now been run on production.
+
+### Example app change
+
+Old
+```
+api_client.temp_script_countersign_agreement(framework_agreement_id, countersigned_path, countersigned_at, user)
+```
+
+New
+
+You can't do this any more.
+
 ## 6.0.0
 
 PR: [#31](https://github.com/alphagov/digitalmarketplace-apiclient/pull/31)

--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '6.7.0'
+__version__ = '7.0.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -654,22 +654,6 @@ class DataAPIClient(BaseAPIClient):
             user=user,
         )
 
-    def temp_script_countersign_agreement(
-        self, framework_agreement_id, countersigned_path, countersigned_at, user
-    ):
-        # Temporary route only to be used for a one off script
-        # Afterwards this route can be deleted
-        return self._post_with_updated_by(
-            "/agreements/{}/countersign-script".format(framework_agreement_id),
-            data={
-                "agreement": {
-                    "countersignedAgreementPath": countersigned_path,
-                    "countersignedAgreementReturnedAt": countersigned_at
-                }
-            },
-            user=user,
-        )
-
     def put_signed_agreement_on_hold(self, framework_agreement_id, user):
         return self._post_with_updated_by(
             "/agreements/{}/on-hold".format(framework_agreement_id),

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1876,29 +1876,6 @@ class TestDataApiClient(object):
             "updated_by": "user@example.com",
         }
 
-    def test_temp_script_countersign_agreement(self, data_client, rmock):
-        # Test for temporary route. Can be deleted after script is run.
-        rmock.post(
-            "http://baseurl/agreements/12345/countersign-script",
-            json={"agreement": {'details': 'here'}},
-            status_code=200)
-
-        result = data_client.temp_script_countersign_agreement(
-            12345,
-            "example/path/file.pdf",
-            "2016-11-01T00:00:00.000000Z",
-            "user@example.com"
-        )
-
-        assert result == {"agreement": {'details': 'here'}}
-        assert rmock.last_request.json() == {
-            "agreement": {
-                "countersignedAgreementPath": "example/path/file.pdf",
-                "countersignedAgreementReturnedAt": "2016-11-01T00:00:00.000000Z"
-            },
-            "updated_by": "user@example.com",
-        }
-
 
 class TestDataAPIClientIterMethods(object):
     def _test_find_iter(self, data_client, rmock, method_name, model_name, url_path):


### PR DESCRIPTION
This route only existed for a script. Now it's been run so we can remove it.