### PR TITLE
Add countersign agreement route

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '6.7.0'
+__version__ = '6.8.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -676,3 +676,10 @@ class DataAPIClient(BaseAPIClient):
             data={},
             user=user
         )
+
+    def countersign_agreement(self, framework_agreement_id, user):
+        return self._post_with_updated_by(
+            "/agreements/{}/countersign".format(framework_agreement_id),
+            data={},
+            user=user
+        )


### PR DESCRIPTION
Part of (this story on Pivotal)[https://www.pivotaltracker.com/story/show/128842457].

The admin frontend needs to be able to mark `framework_agreements` as countersigned. There's a new route on the API (PR is (here)[https://github.com/alphagov/digitalmarketplace-api/pull/466]) to deal with this.

This route on the apiclient hooks the two together.

It may need updating in future depending on how the `countersigned_agreement_path` is going to be set.