### PR TITLE
Add countersign agreement route

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '7.0.0'
+__version__ = '7.1.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -660,3 +660,10 @@ class DataAPIClient(BaseAPIClient):
             data={},
             user=user
         )
+
+    def countersign_agreement(self, framework_agreement_id, user):
+        return self._post_with_updated_by(
+            "/agreements/{}/countersign".format(framework_agreement_id),
+            data={},
+            user=user
+        )

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1206,24 +1206,26 @@ class TestDataApiClient(object):
     def test_put_signed_agreement_on_hold(self, data_client, rmock):
         rmock.post(
             "http://baseurl/agreements/101/on-hold",
-            json={},
+            json={'David made me put data in': True},
             status_code=200
         )
 
-        data_client.put_signed_agreement_on_hold(101, 'Chris')
+        result = data_client.put_signed_agreement_on_hold(101, 'Chris')
 
+        assert result == {'David made me put data in': True}
         assert rmock.call_count == 1
         assert rmock.last_request.json() == {'updated_by': 'Chris'}
 
     def test_countersign_agreement(self, data_client, rmock):
         rmock.post(
             "http://baseurl/agreements/101/countersign",
-            json={},
+            json={'David made me put data in': True},
             status_code=200
         )
 
-        data_client.countersign_agreement(101, 'Chris')
+        result = data_client.countersign_agreement(101, 'Chris')
 
+        assert result == {'David made me put data in': True}
         assert rmock.call_count == 1
         assert rmock.last_request.json() == {'updated_by': 'Chris'}
 

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1215,6 +1215,18 @@ class TestDataApiClient(object):
         assert rmock.call_count == 1
         assert rmock.last_request.json() == {'updated_by': 'Chris'}
 
+    def test_countersign_agreement(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/agreements/101/countersign",
+            json={},
+            status_code=200
+        )
+
+        data_client.countersign_agreement(101, 'Chris')
+
+        assert rmock.call_count == 1
+        assert rmock.last_request.json() == {'updated_by': 'Chris'}
+
     def test_find_draft_services(self, data_client, rmock):
         rmock.get(
             "http://baseurl/draft-services?supplier_id=2",


### PR DESCRIPTION
Part of (this story on Pivotal)[https://www.pivotaltracker.com/story/show/128842457].

The admin frontend needs to be able to mark `framework_agreements` as countersigned. There's a new route on the API (PR is (here)[https://github.com/alphagov/digitalmarketplace-api/pull/466]) to deal with this.

This route on the apiclient hooks the two together.

It may need updating in future depending on how the `countersigned_agreement_path` is going to be set.