### PR TITLE
Send user id when countersigning framework agreements

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '7.1.0'
+__version__ = '7.2.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -661,9 +661,9 @@ class DataAPIClient(BaseAPIClient):
             user=user
         )
 
-    def countersign_agreement(self, framework_agreement_id, user, user_id):
+    def approve_agreement_for_countersignature(self, framework_agreement_id, user, user_id):
         return self._post_with_updated_by(
-            "/agreements/{}/countersign".format(framework_agreement_id),
+            "/agreements/{}/approve".format(framework_agreement_id),
             data={
                 "userId": user_id
             },

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -661,9 +661,11 @@ class DataAPIClient(BaseAPIClient):
             user=user
         )
 
-    def countersign_agreement(self, framework_agreement_id, user):
+    def countersign_agreement(self, framework_agreement_id, user, user_id):
         return self._post_with_updated_by(
             "/agreements/{}/countersign".format(framework_agreement_id),
-            data={},
+            data={
+                "userId": user_id
+            },
             user=user
         )

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1223,11 +1223,11 @@ class TestDataApiClient(object):
             status_code=200
         )
 
-        result = data_client.countersign_agreement(101, 'Chris')
+        result = data_client.countersign_agreement(101, 'chris@example.com', '1234')
 
         assert result == {'David made me put data in': True}
         assert rmock.call_count == 1
-        assert rmock.last_request.json() == {'updated_by': 'Chris'}
+        assert rmock.last_request.json() == {'updated_by': 'chris@example.com', 'userId': '1234'}
 
     def test_find_draft_services(self, data_client, rmock):
         rmock.get(

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1216,14 +1216,14 @@ class TestDataApiClient(object):
         assert rmock.call_count == 1
         assert rmock.last_request.json() == {'updated_by': 'Chris'}
 
-    def test_countersign_agreement(self, data_client, rmock):
+    def test_approve_agreement_for_countersignature(self, data_client, rmock):
         rmock.post(
-            "http://baseurl/agreements/101/countersign",
+            "http://baseurl/agreements/101/approve",
             json={'David made me put data in': True},
             status_code=200
         )
 
-        result = data_client.countersign_agreement(101, 'chris@example.com', '1234')
+        result = data_client.approve_agreement_for_countersignature(101, 'chris@example.com', '1234')
 
         assert result == {'David made me put data in': True}
         assert rmock.call_count == 1


### PR DESCRIPTION
Part of [this story on Pivotal](https://www.pivotaltracker.com/story/show/128842457).

When countersigning agreements, the id of the admin who clicked the button to approve agreement needs to be recorded. This updates the relevant routes on the client to accept this id and sent it through to the api.