### PR TITLE
Add 'agreement' key to expected json data to approve an agreement

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '7.2.0'
+__version__ = '7.2.1'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -665,7 +665,7 @@ class DataAPIClient(BaseAPIClient):
         return self._post_with_updated_by(
             "/agreements/{}/approve".format(framework_agreement_id),
             data={
-                "userId": user_id
+                "agreement": {"userId": user_id}
             },
             user=user
         )

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1227,7 +1227,7 @@ class TestDataApiClient(object):
 
         assert result == {'David made me put data in': True}
         assert rmock.call_count == 1
-        assert rmock.last_request.json() == {'updated_by': 'chris@example.com', 'userId': '1234'}
+        assert rmock.last_request.json() == {'updated_by': 'chris@example.com', 'agreement': {'userId': '1234'}}
 
     def test_find_draft_services(self, data_client, rmock):
         rmock.get(


### PR DESCRIPTION
All API calls should have a top level key that represents the object that is being changed. We had forgotten the 'agreement' key and had been sending the framework agreement data in the top level so this has been fixed to be consistent with the rest of our app.

See related [API pull request](https://github.com/alphagov/digitalmarketplace-api/pull/472).