### PR TITLE
Iterate through brief-responses

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '7.4.0'
+__version__ = '7.5.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -637,6 +637,8 @@ class DataAPIClient(BaseAPIClient):
                 "supplier_id": supplier_id,
             })
 
+    find_brief_responses_iter = make_iter_method('find_brief_responses', 'briefResponses', 'brief-responses')
+
     def add_brief_clarification_question(self, brief_id, question, answer, user):
         return self._post_with_updated_by(
             "/briefs/{}/clarification-questions".format(brief_id),

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1975,6 +1975,13 @@ class TestDataAPIClientIterMethods(object):
             model_name='users',
             url_path='users')
 
+    def test_find_briefs_iter(self, data_client, rmock):
+        self._test_find_iter(
+            data_client, rmock,
+            method_name='find_briefs_iter',
+            model_name='briefs',
+            url_path='briefs')
+
     def test_find_brief_responses_iter(self, data_client, rmock):
         self._test_find_iter(
             data_client, rmock,

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1975,6 +1975,13 @@ class TestDataAPIClientIterMethods(object):
             model_name='users',
             url_path='users')
 
+    def test_find_brief_responses_iter(self, data_client, rmock):
+        self._test_find_iter(
+            data_client, rmock,
+            method_name='find_brief_responses_iter',
+            model_name='briefResponses',
+            url_path='brief-responses')
+
     def test_find_audit_events_iter(self, data_client, rmock):
         self._test_find_iter(
             data_client, rmock,


### PR DESCRIPTION
Ash has asked for a list of BriefResponses as part of [the recurring data story](https://www.pivotaltracker.com/story/show/131078097).

This pull request adds the needed `iter` method, a test for it, and a test that we were missing.