### PR TITLE
Create submit brief response route

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '7.6.0'
+__version__ = '7.7.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -625,6 +625,13 @@ class DataAPIClient(BaseAPIClient):
             user=user,
         )
 
+    def submit_brief_response(self, brief_response_id, user):
+        return self._post_with_updated_by(
+            "/brief-responses/{}/submit".format(brief_response_id),
+            data={},
+            user=user,
+        )
+
     def get_brief_response(self, brief_response_id):
         return self._get(
             "/brief-responses/{}".format(brief_response_id))

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1843,6 +1843,21 @@ class TestDataApiClient(object):
             "updated_by": "user@email.com"
         }
 
+    def test_submit_brief_response(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/brief-responses/123/submit",
+            json={"briefResponses": "result"},
+            status_code=200,
+        )
+
+        result = data_client.submit_brief_response(123, "user@email.com")
+
+        assert result == {"briefResponses": "result"}
+
+        assert rmock.last_request.json() == {
+            "updated_by": "user@email.com"
+        }
+
     def test_get_brief_response(self, data_client, rmock):
         rmock.get(
             "http://baseurl/brief-responses/123",


### PR DESCRIPTION
Part of this story on Pivotal [https://www.pivotaltracker.com/story/show/129838783](https://www.pivotaltracker.com/story/show/129838783).

There's a new view on the API to allow brief_responses to be submitted. This route allows frontend apps to call it.