### PR TITLE
Send back page questions when creating a brief response

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '7.7.0'
+__version__ = '7.8.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -615,12 +615,13 @@ class DataAPIClient(BaseAPIClient):
             params={"supplier_id": supplier_id}
         )['services']) > 0
 
-    def create_brief_response(self, brief_id, supplier_id, data, user):
+    def create_brief_response(self, brief_id, supplier_id, data, user, page_questions=None):
         data = dict(data, briefId=brief_id, supplierId=supplier_id)
         return self._post_with_updated_by(
             "/brief-responses",
             data={
-                "briefResponses": data
+                "briefResponses": data,
+                "page_questions": page_questions or [],
             },
             user=user,
         )

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1822,7 +1822,29 @@ class TestDataApiClient(object):
 
         assert result is False
 
-    def test_create_brief_response(self, data_client, rmock):
+    def test_create_brief_response_with_page_questions(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/brief-responses",
+            json={"briefs": "result"},
+            status_code=201,
+        )
+
+        result = data_client.create_brief_response(
+            1, 2, {"essentialRequirements": [True, None, False]}, "user@email.com", page_questions=['question']
+        )
+
+        assert result == {"briefs": "result"}
+        assert rmock.last_request.json() == {
+            "briefResponses": {
+                "briefId": 1,
+                "supplierId": 2,
+                "essentialRequirements": [True, None, False],
+            },
+            "page_questions": ['question'],
+            "updated_by": "user@email.com"
+        }
+
+    def test_create_brief_response_without_page_questions(self, data_client, rmock):
         rmock.post(
             "http://baseurl/brief-responses",
             json={"briefs": "result"},
@@ -1840,6 +1862,7 @@ class TestDataApiClient(object):
                 "supplierId": 2,
                 "essentialRequirements": [True, None, False],
             },
+            "page_questions": [],
             "updated_by": "user@email.com"
         }
 


### PR DESCRIPTION
Similar to how is done for creating a brief.

We will therefore be able to validate certain questions when creating a brief response (rather than having to validate all of them or not validating any of them).
