### PR TITLE
Update brief response route

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '7.9.0'
+__version__ = '7.10.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -626,6 +626,16 @@ class DataAPIClient(BaseAPIClient):
             user=user,
         )
 
+    def update_brief_response(self, brief_response_id, data, user, page_questions=None):
+        return self._post_with_updated_by(
+            "/brief-responses/{}".format(brief_response_id),
+            data={
+                "briefResponses": data,
+                "page_questions": page_questions or [],
+            },
+            user=user,
+        )
+
     def submit_brief_response(self, brief_response_id, user):
         return self._post_with_updated_by(
             "/brief-responses/{}/submit".format(brief_response_id),

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1866,6 +1866,29 @@ class TestDataApiClient(object):
             "updated_by": "user@email.com"
         }
 
+    def test_update_brief_response(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/brief-responses/1234",
+            json={"briefs": "result"},
+            status_code=200,
+        )
+
+        result = data_client.update_brief_response(
+            1234,
+            {'email_address': 'test@example.com'},
+            'user@example.com',
+            ['email_address']
+        )
+
+        assert result == {"briefs": "result"}
+        assert rmock.last_request.json() == {
+            "briefResponses": {
+                'email_address': 'test@example.com'
+            },
+            "page_questions": ['email_address'],
+            "updated_by": "user@example.com"
+        }
+
     def test_submit_brief_response(self, data_client, rmock):
         rmock.post(
             "http://baseurl/brief-responses/123/submit",


### PR DESCRIPTION
Part of this story on Pivotal [https://www.pivotaltracker.com/story/show/129843611](https://www.pivotaltracker.com/story/show/129843611)

The new flow for brief_responses on the supplier frontend needs to be able to send updates to brief_responses to the api. This adds a route on the client to allow it.