### PR TITLE
Throwing if particular API client is not configured.

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '7.10.0'
+__version__ = '7.11.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/base.py
+++ b/dmapiclient/base.py
@@ -8,11 +8,14 @@ except ImportError:
 
 import requests
 from flask import has_request_context, request, current_app
+
 import backoff
 from monotonic import monotonic
 
 from . import __version__
 from .errors import APIError, HTTPError, HTTPTemporaryError, InvalidResponse
+from .exceptions import ImproperlyConfigured
+
 
 logger = logging.getLogger(__name__)
 
@@ -76,9 +79,9 @@ class BaseAPIClient(object):
     def _request(self, method, url, data=None, params=None):
         if not self.enabled:
             return None
-        if self.base_url is None:
-            logger.info("{} has no URL configured".format(self.__class__.__name__))
-            return None
+
+        if not self.base_url:
+            raise ImproperlyConfigured("{} has no URL configured".format(self.__class__.__name__))
 
         url = urlparse.urljoin(self.base_url, url)
 

--- a/dmapiclient/base.py
+++ b/dmapiclient/base.py
@@ -76,6 +76,9 @@ class BaseAPIClient(object):
     def _request(self, method, url, data=None, params=None):
         if not self.enabled:
             return None
+        if self.base_url is None:
+            logger.info("{} has no URL configured".format(self.__class__.__name__))
+            return None
 
         url = urlparse.urljoin(self.base_url, url)
 

--- a/dmapiclient/exceptions.py
+++ b/dmapiclient/exceptions.py
@@ -1,0 +1,5 @@
+class ImproperlyConfigured(Exception):
+    """
+    Base class for any kind of configuration error, a-la Django / Flask-Via
+    """
+    pass

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -13,6 +13,7 @@ from dmapiclient import APIError, HTTPError, InvalidResponse
 from dmapiclient.errors import REQUEST_ERROR_STATUS_CODE
 from dmapiclient.errors import REQUEST_ERROR_MESSAGE
 from dmapiclient.audit import AuditTypes
+from dmapiclient.exceptions import ImproperlyConfigured
 
 
 @pytest.yield_fixture
@@ -176,9 +177,10 @@ class TestBaseApiClient(object):
         base_client._request('GET', 'https://host/path/')
         assert rmock.called
 
-    def test_null_api_does_nothing(self):
+    def test_null_api_throws(self):
         bad_client = BaseAPIClient(None, 'auth-token', True)
-        assert bad_client._request('GET', '/anything') is None
+        with pytest.raises(ImproperlyConfigured):
+            bad_client._request('GET', '/anything')
 
 
 class TestSearchApiClient(object):

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -176,6 +176,10 @@ class TestBaseApiClient(object):
         base_client._request('GET', 'https://host/path/')
         assert rmock.called
 
+    def test_null_api_does_nothing(self):
+        bad_client = BaseAPIClient(None, 'auth-token', True)
+        assert bad_client._request('GET', '/anything') is None
+
 
 class TestSearchApiClient(object):
     def test_init_app_sets_attributes(self, search_client):


### PR DESCRIPTION
Fix crash on status URI when some API is not actually configured in the environment.