### PR TITLE
init_app: annotate self onto app instance provided in both DataAPIClient & SearchAPIClient

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '7.11.0'
+__version__ = '7.12.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -9,6 +9,8 @@ class DataAPIClient(BaseAPIClient):
         self.base_url = app.config['DM_DATA_API_URL']
         self.auth_token = app.config['DM_DATA_API_AUTH_TOKEN']
 
+        app.data_api_client = self
+
     # Audit Events
 
     def find_audit_events(

--- a/dmapiclient/search.py
+++ b/dmapiclient/search.py
@@ -14,6 +14,8 @@ class SearchAPIClient(BaseAPIClient):
         self.auth_token = app.config['DM_SEARCH_API_AUTH_TOKEN']
         self.enabled = app.config['ES_ENABLED']
 
+        app.search_api_client = self
+
     def _url(self, index, path):
         return u"/{}/services/{}".format(index, path)
 

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -196,6 +196,7 @@ class TestSearchApiClient(object):
         assert search_client.base_url == "http://example"
         assert search_client.auth_token == "example-token"
         assert not search_client.enabled
+        assert app.search_api_client is search_client
 
     def test_get_status(self, search_client, rmock):
         rmock.get(
@@ -385,6 +386,7 @@ class TestDataApiClient(object):
 
         assert data_client.base_url == "http://example"
         assert data_client.auth_token == "example-token"
+        assert app.data_api_client is data_client
 
     def test_get_status(self, data_client, rmock):
         rmock.get(


### PR DESCRIPTION
Following a standard pattern from flask extensions, I've made `DataAPIClient` and `SearchAPIClient`'s `init_app` methods annotate themselves onto the provided `app` instance via `data_api_client` and `search_api_client` attributes respectively.

This would allow frontend code to access the api clients in a more uniform & robust way (through `current_app`) than they are currently doing. I have a branch of the admin frontend with associated changes brewing as a proposal/strawman - this PR is intended to go with that - on its own this PR is meaningless, so just disregard until then.