### PR TITLE
adding publishedAt to the brief stub when status is closed

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '7.11.0'
+__version__ = '7.12.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/api_stubs.py
+++ b/dmapiclient/api_stubs.py
@@ -55,7 +55,7 @@ def brief(status="draft",
             "clarificationQuestions": clarification_questions or [],
         }
     }
-    if status == "live":
+    if status in ("live", "closed"):
         brief['briefs']['publishedAt'] = "2016-03-29T10:11:14.000000Z"
         brief['briefs']['applicationsClosedAt'] = "2016-04-07T00:00:00.000000Z"
         brief['briefs']['clarificationQuestionsClosedAt'] = "2016-04-02T00:00:00.000000Z"

--- a/tests/test_api_stubs.py
+++ b/tests/test_api_stubs.py
@@ -128,3 +128,31 @@ def test_brief():
             "clarificationQuestions": [],
         }
     }
+
+    assert api_stubs.brief(
+        status='closed',
+        framework_slug='a-framework-slug',
+        lot_slug='a-lot-slug', user_id=234,
+        framework_name='A Framework Name') \
+        == {
+        "briefs": {
+            "id": 1234,
+            "title": "I need a thing to do a thing",
+            "frameworkSlug": "a-framework-slug",
+            "frameworkName": "A Framework Name",
+            "lotSlug": "a-lot-slug",
+            "status": "closed",
+            "users": [{"active": True,
+                       "role": "buyer",
+                       "emailAddress": "buyer@email.com",
+                       "id": 234,
+                       "name": "Buyer User"}],
+            "createdAt": "2016-03-29T10:11:12.000000Z",
+            "updatedAt": "2016-03-29T10:11:13.000000Z",
+            "publishedAt": "2016-03-29T10:11:14.000000Z",
+            "applicationsClosedAt": "2016-04-07T00:00:00.000000Z",
+            "clarificationQuestionsClosedAt": "2016-04-02T00:00:00.000000Z",
+            "clarificationQuestionsAreClosed": False,
+            "clarificationQuestions": [],
+        }
+    }


### PR DESCRIPTION
closed briefs have a publishedAt date too and we are using that to decide which flow to use for things now, this should make those tests easier and fix existing tests that run over old flows.