### PR TITLE
Kill the import_* wrapper methods

### DIFF
--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -101,12 +101,6 @@ class DataAPIClient(BaseAPIClient):
             "/suppliers/{}".format(supplier_id)
         )
 
-    def import_supplier(self, supplier_id, supplier):
-        return self._put(
-            "/suppliers/{}".format(supplier_id),
-            data={"suppliers": supplier},
-        )
-
     def create_supplier(self, supplier):
         return self._post(
             "/suppliers",
@@ -508,15 +502,6 @@ class DataAPIClient(BaseAPIClient):
         return self._get("/services", params=params)
 
     find_services_iter = make_iter_method('find_services', 'services', 'services')
-
-    def import_service(self, service_id, service, user):
-        return self._put_with_updated_by(
-            "/services/{}".format(service_id),
-            data={
-                "services": service,
-            },
-            user=user,
-        )
 
     def update_service(self, service_id, service, user):
         return self._post_with_updated_by(

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -472,19 +472,6 @@ class TestDataApiClient(object):
         assert result == {"services": "result"}
         assert rmock.called
 
-    def test_import_service(self, data_client, rmock):
-        rmock.put(
-            "http://baseurl/services/123",
-            json={"services": "result"},
-            status_code=201,
-        )
-
-        result = data_client.import_service(
-            123, {"foo": "bar"}, "person")
-
-        assert result == {"services": "result"}
-        assert rmock.called
-
     def test_update_service(self, data_client, rmock):
         rmock.post(
             "http://baseurl/services/123",
@@ -917,18 +904,6 @@ class TestDataApiClient(object):
             data_client.get_supplier(123)
         except HTTPError:
             assert rmock.called
-
-    def test_import_supplier(self, data_client, rmock):
-        rmock.put(
-            "http://baseurl/suppliers/123",
-            json={"suppliers": "result"},
-            status_code=201,
-        )
-
-        result = data_client.import_supplier(123, {"foo": "bar"})
-
-        assert result == {"suppliers": "result"}
-        assert rmock.called
 
     def test_create_supplier(self, data_client, rmock):
         rmock.post(


### PR DESCRIPTION
Now that we have a better way of doing data migrations onto local dev machines, we can obliterate the supplier/service import routes.

The only place these methods are used is in the import script found in the API. A subsequent pull request on the API will remove the script as well as the routes that actually do the imports.