### PR TITLE
NO-TICKET-specify-packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
   - "3.4"
 install:
   - pip install -r requirements_for_test.txt
-  - pip install -e .
 script:
   - ./scripts/run_tests.sh --cov=dmapiclient --cov-report=term-missing
 after_success:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,1 @@
-backoff==1.0.7
-Flask>=0.10
-six==1.9.0
-requests==2.7.0
-enum34==1.1.2
-monotonic==0.3
+-e .

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [pep8]
 max-line-length = 120
+
+[pytest]
+norecursedirs = venv*

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
 import re
 import ast
-import pip.download
-from pip.req import parse_requirements
 from setuptools import setup, find_packages
 
 
@@ -10,10 +8,6 @@ _version_re = re.compile(r'__version__\s+=\s+(.*)')
 with open('dmapiclient/__init__.py', 'rb') as f:
     version = str(ast.literal_eval(_version_re.search(
         f.read().decode('utf-8')).group(1)))
-
-requirements = list(parse_requirements('requirements.txt', session=pip.download.PipSession()))
-
-install_requires = [str(r.req) for r in requirements]
 
 setup(
     name='digitalmarketplace-apiclient',
@@ -25,5 +19,12 @@ setup(
     long_description=__doc__,
     packages=find_packages(),
     include_package_data=True,
-    install_requires=install_requires
+    install_requires=[
+        'Flask>=0.10',
+        'backoff==1.0.7',
+        'enum34==1.1.2',
+        'monotonic==0.3',
+        'requests==2.7.0',
+        'six==1.9.0'
+    ]
 )


### PR DESCRIPTION
#### Remove `__init__.py` which are causing tests to be installed as a module

Remove `tests/*__init__.py` files to avoid tests being added by `find_packages` in `setup.py`.

Explained in depth here:

https://docs.google.com/a/digital.cabinet-office.gov.uk/document/d/1cQFNx4WEvI-IGZ1g9K8JtZfeplrEmoJbtBOOpaJSEdQ