### PR TITLE
Add audit event for updating a briefs framework id

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '8.1.0'
+__version__ = '8.2.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/audit.py
+++ b/dmapiclient/audit.py
@@ -34,6 +34,7 @@ class AuditTypes(Enum):
     submit_brief_response = "submit_brief_response"
     add_brief_clarification_question = "add_brief_clarification_question"
     delete_brief = "delete_brief"
+    update_brief_framework_id = "update_brief_framework_id"
 
     # Supplier actions
     register_framework_interest = "register_framework_interest"


### PR DESCRIPTION
Part of this story on Pivital [https://www.pivotaltracker.com/story/show/137359003](https://www.pivotaltracker.com/story/show/137359003)

Draft DOS1 briefs need to be migrated to become draft DOS2 briefs when
DOS1 closes and DOS2 opens. An audit event of this would be nice.

This PR [https://github.com/alphagov/digitalmarketplace-api/pull/534](https://github.com/alphagov/digitalmarketplace-api/pull/534) on the API is for the migration which does this, and it now includes creating audit events for each record updated. This new audit type is used here.