### PR TITLE
Fix enum34 install error on Python 3.6

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '8.4.0'
+__version__ = '8.4.1'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     install_requires=[
         'Flask>=0.10',
         'backoff==1.0.7',
-        'enum34==1.1.2',
+        'enum34==1.1.6',
         'monotonic==0.3',
         'requests==2.7.0',
         'six==1.9.0'


### PR DESCRIPTION
enum34 1.1.2 failed to install on Python 3.6, so I'm bumping it to
the latest version (1.1.6) which has a pre-built wheel.