### PR TITLE
Create `find_framework_suppliers_iter`

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '8.6.0'
+__version__ = '8.7.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/base.py
+++ b/dmapiclient/base.py
@@ -20,12 +20,11 @@ from .exceptions import ImproperlyConfigured
 logger = logging.getLogger(__name__)
 
 
-def make_iter_method(method_name, model_name, url_path):
+def make_iter_method(method_name, model_name):
     """Make a page-concatenating iterator method from a find method
 
     :param method_name: The name of the find method to decorate
     :param model_name: The name of the model as it appears in the JSON response
-    :param url_path: The URL path for the API -- FIXME parameter ignored?
     """
     backoff_decorator = backoff.on_exception(backoff.expo, HTTPTemporaryError, max_tries=5)
 

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -47,7 +47,7 @@ class DataAPIClient(BaseAPIClient):
             params=params
         )
 
-    find_audit_events_iter = make_iter_method('find_audit_events', 'auditEvents', 'audit-events')
+    find_audit_events_iter = make_iter_method('find_audit_events', 'auditEvents')
 
     def acknowledge_audit_event(self, audit_event_id, user):
         return self._post_with_updated_by(
@@ -94,7 +94,7 @@ class DataAPIClient(BaseAPIClient):
             params=params
         )
 
-    find_suppliers_iter = make_iter_method('find_suppliers', 'suppliers', 'suppliers')
+    find_suppliers_iter = make_iter_method('find_suppliers', 'suppliers')
 
     def get_supplier(self, supplier_id):
         return self._get(
@@ -297,7 +297,7 @@ class DataAPIClient(BaseAPIClient):
             params['page'] = page
         return self._get("/users", params=params)
 
-    find_users_iter = make_iter_method('find_users', 'users', 'users')
+    find_users_iter = make_iter_method('find_users', 'users')
 
     def get_user(self, user_id=None, email_address=None):
         if user_id is not None and email_address is not None:
@@ -419,7 +419,7 @@ class DataAPIClient(BaseAPIClient):
 
         return self._get('/draft-services', params=params)
 
-    find_draft_services_iter = make_iter_method('find_draft_services', 'services', 'draft-services')
+    find_draft_services_iter = make_iter_method('find_draft_services', 'services')
 
     def get_draft_service(self, draft_id):
         return self._get(
@@ -522,7 +522,7 @@ class DataAPIClient(BaseAPIClient):
 
         return self._get("/services", params=params)
 
-    find_services_iter = make_iter_method('find_services', 'services', 'services')
+    find_services_iter = make_iter_method('find_services', 'services')
 
     def update_service(self, service_id, service, user):
         return self._post_with_updated_by(
@@ -607,7 +607,7 @@ class DataAPIClient(BaseAPIClient):
                     }
         )
 
-    find_briefs_iter = make_iter_method('find_briefs', 'briefs', 'briefs')
+    find_briefs_iter = make_iter_method('find_briefs', 'briefs')
 
     def delete_brief(self, brief_id, user):
         return self._delete_with_updated_by(
@@ -663,7 +663,7 @@ class DataAPIClient(BaseAPIClient):
                 "status": status
             })
 
-    find_brief_responses_iter = make_iter_method('find_brief_responses', 'briefResponses', 'brief-responses')
+    find_brief_responses_iter = make_iter_method('find_brief_responses', 'briefResponses')
 
     def add_brief_clarification_question(self, brief_id, question, answer, user):
         return self._post_with_updated_by(

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -275,6 +275,8 @@ class DataAPIClient(BaseAPIClient):
             params=params
         )
 
+    find_framework_suppliers_iter = make_iter_method('find_framework_suppliers', 'supplierFrameworks')
+
     # Users
 
     def create_user(self, user):

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -2107,6 +2107,30 @@ class TestDataAPIClientIterMethods(object):
             model_name='suppliers',
             url_path='suppliers')
 
+    def test_find_framework_suppliers_iter(self, data_client, rmock):
+        rmock.get(
+            'http://baseurl/frameworks/g-cloud-8/suppliers',
+            json={
+                'links': {'next': 'http://baseurl/frameworks/g-cloud-8/suppliers?page=2'},
+                'supplierFrameworks': [{'id': 1}, {'id': 2}]
+            },
+            status_code=200)
+        rmock.get(
+            'http://baseurl/frameworks/g-cloud-8/suppliers?page=2',
+            json={
+                'links': {'prev': 'http://baseurl/frameworks/g-cloud-8/suppliers'},
+                'supplierFrameworks': [{'id': 3}]
+            },
+            status_code=200)
+
+        result = data_client.find_framework_suppliers_iter('g-cloud-8')
+        results = list(result)
+
+        assert len(results) == 3
+        assert results[0]['id'] == 1
+        assert results[1]['id'] == 2
+        assert results[2]['id'] == 3
+
     def test_find_draft_services_iter(self, data_client, rmock):
         rmock.get(
             'http://baseurl/draft-services?supplier_id=123',


### PR DESCRIPTION
This has been created to allow the `get-model-data` script to get all suppliers associate with a framework.

The `url_path` parameter has also been removed from `make_iter_method` as it was unused.