### PR TITLE
Add aggregations method to search api client

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '8.9.0'
+__version__ = '8.10.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/search.py
+++ b/dmapiclient/search.py
@@ -43,6 +43,11 @@ class SearchAPIClient(BaseAPIClient):
                 raise
         return None
 
+    def _add_filters_to_params(self, params, filters):
+        """In-place transformation of filter keys and storage in params."""
+        for filter_name, filter_values in six.iteritems(filters):
+            params[u'filter_{}'.format(filter_name)] = filter_values
+
     def search_services(self, q=None, page=None, index=DEFAULT_SEARCH_INDEX, **filters):
         params = {}
         if q is not None:
@@ -51,8 +56,19 @@ class SearchAPIClient(BaseAPIClient):
         if page:
             params['page'] = page
 
-        for filter_name, filter_values in six.iteritems(filters):
-            params[u'filter_{}'.format(filter_name)] = filter_values
+        self._add_filters_to_params(params, filters)
 
         response = self._get(self._url(index, "search"), params=params)
+        return response
+
+    def aggregate_services(self, q=None, index=DEFAULT_SEARCH_INDEX, aggregations=[], **filters):
+        params = {}
+        if q is not None:
+            params['q'] = q
+
+        self._add_filters_to_params(params, filters)
+
+        params['aggregations'] = aggregations
+
+        response = self._get(self._url(index, "aggregations"), params=params)
         return response

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -300,17 +300,32 @@ class TestSearchApiClient(object):
             search_client.index("12345", service)
 
     def test_search_services(self, search_client, rmock):
+        expected_response = {'services': "myresponse"}
         rmock.get(
             'http://baseurl/g-cloud/services/search?q=foo&'
             'filter_minimumContractPeriod=a&'
             'filter_something=a&filter_something=b',
-            json={'services': "myresponse"},
+            json=expected_response,
             status_code=200)
         result = search_client.search_services(
             q='foo',
             minimumContractPeriod=['a'],
             something=['a', 'b'])
-        assert result == {'services': "myresponse"}
+        assert result == expected_response
+
+    def test_aggregate_services(self, search_client, rmock):
+        expected_response = {'aggregations': "myresponse"}
+        rmock.get(
+            'http://baseurl/g-cloud/services/aggregations?q=foo&'
+            'filter_minimumContractPeriod=a&'
+            'filter_something=a&filter_something=b',
+            json=expected_response,
+            status_code=200)
+        result = search_client.aggregate_services(
+            q='foo',
+            minimumContractPeriod=['a'],
+            something=['a', 'b'])
+        assert result == expected_response
 
     def test_search_given_index(self, search_client, rmock):
         rmock.get(


### PR DESCRIPTION
## Summary
Implements support for the search-api's `aggregations` endpoint.
Bump version to 8.10.0

## Ticket
https://trello.com/c/5LRAkydD/481-show-number-of-services-within-category