### PR TITLE
only conditionally depend on enum34 (if python < 3.4)

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '8.10.0'
+__version__ = '8.10.1'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,10 @@
 import re
 import ast
+import sys
 from setuptools import setup, find_packages
+
+
+has_enum = sys.version_info >= (3, 4)
 
 
 _version_re = re.compile(r'__version__\s+=\s+(.*)')
@@ -22,9 +26,8 @@ setup(
     install_requires=[
         'Flask>=0.10',
         'backoff==1.0.7',
-        'enum34==1.1.6',
         'monotonic==0.3',
         'requests==2.7.0',
         'six==1.9.0'
-    ]
+    ] + ([] if has_enum else ['enum34==1.1.6'])
 )


### PR DESCRIPTION
This is needed because `enum34` won't work on python >= 3.4.

The trick used is directly from the `enum_compat` python package (the advantage over just using that is retaining finer control over versions).