### PR TITLE
Try again when getting back 502 errors

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '8.10.1'
+__version__ = '8.10.2'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/errors.py
+++ b/dmapiclient/errors.py
@@ -29,13 +29,13 @@ class HTTPError(APIError):
     @staticmethod
     def create(e):
         error = HTTPError(e.response)
-        if error.status_code in [503, 504]:
+        if error.status_code in [502, 503, 504]:
             error = HTTPTemporaryError(e.response)
         return error
 
 
 class HTTPTemporaryError(HTTPError):
-    """Specific instance of HTTPError for temporary 503 and 504 errors
+    """Specific instance of HTTPError for temporary 502, 503 and 504 errors
 
     Used for detecting whether failed requests should be retried.
     """

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -2217,11 +2217,14 @@ class TestDataAPIClientIterMethods(object):
 
         assert len(results) == 2
 
+    @pytest.mark.parametrize("status_code", [
+        502, 503, 504
+    ])
     @mock.patch('time.sleep')
-    def test_find_services_backoff_on_503(self, sleep, data_client, rmock):
+    def test_find_services_backoff_on_502_503_504(self, sleep, data_client, rmock, status_code):
         rmock.get(
             'http://baseurl/services',
-            [{'json': {}, 'status_code': 503},
+            [{'json': {}, 'status_code': status_code},
              {'json': {'links': {}, 'services': [{'id': 1}]}, 'status_code': 200}])
 
         result = data_client.find_services_iter()


### PR DESCRIPTION
Previously, it was only 503 or 504 errors would cause the `find_{model}_iter` function to retry the failing call. Now we've added 502 errors as well.

This is to mitigate a problem we're experiencing with exporting brief responses.  It's happened a few times that the `find_brief_responses_iter` function gets through about ~190 pages of brief responses and then fails upon getting back a 502 error.

Manually testing getting back brief responses fails intermittently but not reliably so we're going to make the API client more resilient while we're investigating the problem.

This is a short-term-type solution so that we can complete the data exports, but it doesn't actually do anything to address the failures in the API.