### PR TITLE
Add 'with_clarification_questions' parameter to `find_briefs`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 *.egg-info/
 *.pyc
-venv
+venv*

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.egg-info/
 *.pyc
+venv

--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '8.11.0'
+__version__ = '8.12.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -608,7 +608,10 @@ class DataAPIClient(BaseAPIClient):
         return self._get(
             "/briefs/{}".format(brief_id))
 
-    def find_briefs(self, user_id=None, status=None, framework=None, lot=None, page=None, human=None, with_users=None):
+    def find_briefs(
+        self, user_id=None, status=None, framework=None, lot=None, page=None, human=None, with_users=None,
+        with_clarification_questions=None
+    ):
         return self._get(
             "/briefs",
             params={"user_id": user_id,
@@ -617,7 +620,8 @@ class DataAPIClient(BaseAPIClient):
                     "status": status,
                     "page": page,
                     "human": human,
-                    "with_users": with_users
+                    "with_users": with_users,
+                    "with_clarification_questions": with_clarification_questions
                     }
         )
 

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1873,6 +1873,17 @@ class TestDataApiClient(object):
         assert rmock.called
         assert result == {"briefs": [{"biscuit": "tasty"}]}
 
+    def test_find_briefs_with_clarification_questions(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/briefs?with_clarification_questions=True",
+            json={"briefs": [{"biscuit": "tasty"}]},
+            status_code=200)
+
+        result = data_client.find_briefs(with_clarification_questions=True)
+
+        assert rmock.called
+        assert result == {"briefs": [{"biscuit": "tasty"}]}
+
     def test_delete_brief(self, data_client, rmock):
         rmock.delete(
             "http://baseurl/briefs/2",


### PR DESCRIPTION
This is part of a story to tell interested suppliers that a question has been answered.

Related dm-api pull request: https://github.com/alphagov/digitalmarketplace-api/pull/614

Trello ticket: https://trello.com/c/2noI0EFB/472-tell-interested-suppliers-that-a-question-has-been-answered