### PR TITLE
Data API client methods for awarding brief_response + award details

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '8.13.0'
+__version__ = '8.14.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -607,6 +607,20 @@ class DataAPIClient(BaseAPIClient):
             user=updated_by,
         )
 
+    def update_brief_award_brief_response(self, brief_id, brief_response_id, updated_by):
+        return self._post_with_updated_by(
+            "/briefs/{}/award".format(brief_id),
+            data={"brief_response_id": brief_response_id},
+            user=updated_by,
+        )
+
+    def update_brief_award_details(self, brief_id, brief_response_id, award_details, updated_by):
+        return self._post_with_updated_by(
+            "/briefs/{}/award/{}/contract-details".format(brief_id, brief_response_id),
+            data={"award_details": award_details},
+            user=updated_by,
+        )
+
     def publish_brief(self, brief_id, user):
         return self._post_with_updated_by(
             "/briefs/{}/publish".format(brief_id),

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -610,14 +610,14 @@ class DataAPIClient(BaseAPIClient):
     def update_brief_award_brief_response(self, brief_id, brief_response_id, updated_by):
         return self._post_with_updated_by(
             "/briefs/{}/award".format(brief_id),
-            data={"brief_response_id": brief_response_id},
+            data={"briefResponseId": brief_response_id},
             user=updated_by,
         )
 
     def update_brief_award_details(self, brief_id, brief_response_id, award_details, updated_by):
         return self._post_with_updated_by(
             "/briefs/{}/award/{}/contract-details".format(brief_id, brief_response_id),
-            data={"award_details": award_details},
+            data={"awardDetails": award_details},
             user=updated_by,
         )
 

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1825,6 +1825,41 @@ class TestDataApiClient(object):
             "updated_by": "user@email.com"
         }
 
+    def test_update_brief_award_brief_response(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/briefs/123/award",
+            json={"briefs": "result"},
+            status_code=200,
+        )
+
+        result = data_client.update_brief_award_brief_response(123, 456, "user@email.com")
+
+        assert result == {"briefs": "result"}
+        assert rmock.last_request.json() == {
+            "brief_response_id": 456,
+            "updated_by": "user@email.com"
+        }
+
+    def test_update_brief_award_details(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/briefs/123/award/456/contract-details",
+            json={"briefs": "result"},
+            status_code=200,
+        )
+
+        result = data_client.update_brief_award_details(
+            123, 456, {"awardedContractStartDate": "2020-12-31", "contractValue": "99.95"}, "user@email.com"
+        )
+
+        assert result == {"briefs": "result"}
+        assert rmock.last_request.json() == {
+            "award_details": {
+                "awardedContractStartDate": "2020-12-31",
+                "contractValue": "99.95",
+            },
+            "updated_by": "user@email.com"
+        }
+
     def test_publish_brief(self, data_client, rmock):
         rmock.post(
             "http://baseurl/briefs/123/publish",

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1836,7 +1836,7 @@ class TestDataApiClient(object):
 
         assert result == {"briefs": "result"}
         assert rmock.last_request.json() == {
-            "brief_response_id": 456,
+            "briefResponseId": 456,
             "updated_by": "user@email.com"
         }
 
@@ -1853,7 +1853,7 @@ class TestDataApiClient(object):
 
         assert result == {"briefs": "result"}
         assert rmock.last_request.json() == {
-            "award_details": {
+            "awardDetails": {
                 "awardedContractStartDate": "2020-12-31",
                 "contractValue": "99.95",
             },


### PR DESCRIPTION
Ticket: https://trello.com/c/kGVfzXuH/749-3-collect-award-status-on-buyer-dashboard

PR 2 of 4 - API client

See also:
PR 1 of 4: API: https://github.com/alphagov/digitalmarketplace-api/pull/622
PR 3 of 4: Question content: https://github.com/alphagov/digitalmarketplace-frameworks/pull/464
PR 4 of 4: Briefs front end: https://github.com/alphagov/digitalmarketplace-briefs-frontend/pull/12

Introduces two new data API client methods: `update_brief_award_brief_response` (for updating the winning BriefResponse) and `update_brief_award_details` (for updating contract details).