### PR TITLE
Direct Award Projects

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '9.0.0'
+__version__ = '9.1.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/audit.py
+++ b/dmapiclient/audit.py
@@ -60,6 +60,10 @@ class AuditTypes(Enum):
     # Admin actions
     snapshot_framework_stats = "snapshot_framework_stats"
 
+    # Projects
+    create_project = "create_project"
+    create_project_search = "create_project_search"
+
     @staticmethod
     def is_valid_audit_type(test_audit_type):
 

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -778,3 +778,67 @@ class DataAPIClient(BaseAPIClient):
             },
             user=user
         )
+
+    # Direct Award Projects
+
+    def find_direct_award_projects(self, user_id=None, page=None):
+        return self._get(
+            "/direct-award/projects",
+            params={
+                "user_id": user_id,
+                "page": page
+            }
+        )
+
+    find_direct_award_projects_iter = make_iter_method('find_direct_award_projects', 'projects')
+
+    def get_direct_award_project(self, user_id, project_id):
+        return self._get(
+            "/direct-award/projects/{}".format(project_id),
+            params={"user_id": user_id})
+
+    def create_direct_award_project(self, user_id, user_email, project_name):
+        return self._post_with_updated_by(
+            "/direct-award/projects",
+            data={
+                "project": {
+                    "name": project_name,
+                    "user_id": user_id
+                }
+            },
+            user=user_email
+        )
+
+    def find_direct_award_project_searches(self, user_id, project_id, page=None):
+        return self._get(
+            "/direct-award/projects/{}/searches".format(project_id),
+            params={
+                "user_id": user_id,
+                "page": page
+            }
+        )
+
+    find_direct_award_project_searches_iter = make_iter_method('find_direct_award_project_searches', 'projects')
+
+    def create_direct_award_project_search(self, user_id, user_email, project_id, search_url):
+        return self._post_with_updated_by(
+            "/direct-award/projects/{}/searches".format(project_id),
+            data={
+                "search": {
+                    "search_url": search_url,
+                    "user_id": user_id
+                }
+            },
+            user=user_email
+        )
+
+    def get_direct_award_project_search(self, user_id, project_id, search_id):
+        return self._get(
+            "/direct-award/projects/{}/searches/{}".format(project_id, search_id),
+            params={
+                "user_id": user_id
+            }
+        )
+
+    def find_direct_award_project_services(self, user_id, project_id):
+        raise NotImplementedError()

--- a/dmapiclient/search.py
+++ b/dmapiclient/search.py
@@ -13,6 +13,26 @@ class SearchAPIClient(BaseAPIClient):
     def _url(self, index, path):
         return u"/{}/services/{}".format(index, path)
 
+    def get_url(self, path, index, q, page=None, aggregations=[], **filters):
+        params = {}
+        if q is not None:
+            params['q'] = q
+
+        if aggregations:
+            params['aggregations'] = aggregations
+        elif page:
+            params['page'] = page
+
+        self._add_filters_to_params(params, filters)
+
+        return self._build_url(url=self._url(index=index, path=path), params=params)
+
+    def get_search_url(self, index, q='', page=None, **filters):
+        return self.get_url(path='search', index=index, q=q, page=page, **filters)
+
+    def get_aggregations_url(self, index, q='', aggregations=[], **filters):
+        return self.get_url(path='aggregations', index=index, q=q, aggregations=aggregations, **filters)
+
     def create_index(self, index):
         return self._put(
             '/{}'.format(index),
@@ -45,26 +65,15 @@ class SearchAPIClient(BaseAPIClient):
             params[u'filter_{}'.format(filter_name)] = filter_values
 
     def search_services(self, index, q=None, page=None, **filters):
-        params = {}
-        if q is not None:
-            params['q'] = q
-
-        if page:
-            params['page'] = page
-
-        self._add_filters_to_params(params, filters)
-
-        response = self._get(self._url(index, "search"), params=params)
+        response = self._get(self.get_search_url(index=index,
+                                                 q=q,
+                                                 page=page,
+                                                 **filters))
         return response
 
     def aggregate_services(self, index, q=None, aggregations=[], **filters):
-        params = {}
-        if q is not None:
-            params['q'] = q
-
-        self._add_filters_to_params(params, filters)
-
-        params['aggregations'] = aggregations
-
-        response = self._get(self._url(index, "aggregations"), params=params)
+        response = self._get(self.get_aggregations_url(index=index,
+                                                       q=q,
+                                                       aggregations=aggregations,
+                                                       **filters))
         return response


### PR DESCRIPTION
## Summary
Add APIClient methods for interacting with Direct Award projects on the API. Adds methods on the Search API client to generate the full search-api URL that a given call will hit. This is stored by the API for Project searches.

This PR also wraps the `register_uri` function of the rmock and inserts the `complete_qs` parameter, if not supplied. This forces the URLs to match exactly; without it, missing query params would not trigger a failed test case. A couple of tests broke from this change, so fixed those up to properly mock the full URL.

## Other PRs:
API: https://github.com/alphagov/digitalmarketplace-api/pull/624
Buyer FE: https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/581 (for trying out the flow only; not for review yet)

## Ticket
https://trello.com/c/pbJiKaVl/625-api-for-direct-award-projects