### PR TITLE
Remove default index from searchapiclient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 Records breaking changes from major version bumps
 
+## 9.0.0
+
+PR: [#86](https://github.com/alphagov/digitalmarketplace-apiclient/pull/86)
+
+Remove the default index from the Search API Client; it is now a required argument.
+
+### Example app cange
+
+Old
+```python
+search_api_client.search_services(q='hosting')
+```
+
+New
+```python
+search_api_client.search_services(index='g-cloud-9', q='hosting')
+```
+
 ## 8.0.0
 
 PR: [#62](https://github.com/alphagov/digitalmarketplace-apiclient/pull/62)

--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '8.14.0'
+__version__ = '9.0.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/search.py
+++ b/dmapiclient/search.py
@@ -4,10 +4,6 @@ from .base import BaseAPIClient
 from .errors import HTTPError
 
 
-# TODO remove default value once apps pass the index value to SearchAPIClient method calls
-DEFAULT_SEARCH_INDEX = 'g-cloud'
-
-
 class SearchAPIClient(BaseAPIClient):
     def init_app(self, app):
         self.base_url = app.config['DM_SEARCH_API_URL']
@@ -17,9 +13,9 @@ class SearchAPIClient(BaseAPIClient):
     def _url(self, index, path):
         return u"/{}/services/{}".format(index, path)
 
-    def create_index(self, index_name):
+    def create_index(self, index):
         return self._put(
-            '/{}'.format(index_name),
+            '/{}'.format(index),
             data={'type': 'index'}
         )
 
@@ -29,11 +25,11 @@ class SearchAPIClient(BaseAPIClient):
             data={'type': 'alias', 'target': target_index}
         )
 
-    def index(self, service_id, service, index=DEFAULT_SEARCH_INDEX):
+    def index(self, index, service_id, service):
         url = self._url(index, service_id)
         return self._put(url, data={'service': service})
 
-    def delete(self, service_id, index=DEFAULT_SEARCH_INDEX):
+    def delete(self, index, service_id):
         url = self._url(index, service_id)
 
         try:
@@ -48,7 +44,7 @@ class SearchAPIClient(BaseAPIClient):
         for filter_name, filter_values in six.iteritems(filters):
             params[u'filter_{}'.format(filter_name)] = filter_values
 
-    def search_services(self, q=None, page=None, index=DEFAULT_SEARCH_INDEX, **filters):
+    def search_services(self, index, q=None, page=None, **filters):
         params = {}
         if q is not None:
             params['q'] = q
@@ -61,7 +57,7 @@ class SearchAPIClient(BaseAPIClient):
         response = self._get(self._url(index, "search"), params=params)
         return response
 
-    def aggregate_services(self, q=None, index=DEFAULT_SEARCH_INDEX, aggregations=[], **filters):
+    def aggregate_services(self, index, q=None, aggregations=[], **filters):
         params = {}
         if q is not None:
             params['q'] = q


### PR DESCRIPTION
## Summary
We are removing the default index name from the Search API Client and requiring it to be passed explicitly. This is because we are moving away from a single index called 'g-cloud' and moving towards an index-per-framework where the index name is the framework slug. Given this, we can get the index name programmatically and don't need to statically define it anywhere.

Bump version to 9.0.0

## Ticket
Required work under https://trello.com/c/Hlq5mzAy/619-save-a-search-and-create-a-project