### PR TITLE
update apiclient for updated api parameter formats

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '9.1.0'
+__version__ = '9.1.1'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -785,7 +785,7 @@ class DataAPIClient(BaseAPIClient):
         return self._get(
             "/direct-award/projects",
             params={
-                "user_id": user_id,
+                "user-id": user_id,
                 "page": page
             }
         )
@@ -795,7 +795,7 @@ class DataAPIClient(BaseAPIClient):
     def get_direct_award_project(self, user_id, project_id):
         return self._get(
             "/direct-award/projects/{}".format(project_id),
-            params={"user_id": user_id})
+            params={"user-id": user_id})
 
     def create_direct_award_project(self, user_id, user_email, project_name):
         return self._post_with_updated_by(
@@ -803,7 +803,7 @@ class DataAPIClient(BaseAPIClient):
             data={
                 "project": {
                     "name": project_name,
-                    "user_id": user_id
+                    "userId": user_id
                 }
             },
             user=user_email
@@ -813,7 +813,7 @@ class DataAPIClient(BaseAPIClient):
         return self._get(
             "/direct-award/projects/{}/searches".format(project_id),
             params={
-                "user_id": user_id,
+                "user-id": user_id,
                 "page": page
             }
         )
@@ -825,8 +825,8 @@ class DataAPIClient(BaseAPIClient):
             "/direct-award/projects/{}/searches".format(project_id),
             data={
                 "search": {
-                    "search_url": search_url,
-                    "user_id": user_id
+                    "searchUrl": search_url,
+                    "userId": user_id
                 }
             },
             user=user_email
@@ -836,7 +836,7 @@ class DataAPIClient(BaseAPIClient):
         return self._get(
             "/direct-award/projects/{}/searches/{}".format(project_id, search_id),
             params={
-                "user_id": user_id
+                "user-id": user_id
             }
         )
 

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -2170,9 +2170,9 @@ class TestDataApiClient(object):
     @pytest.mark.parametrize('user_id, page, expected_query_string',
                              (
                                  (None, None, ''),
-                                 (123, None, '?user_id=123'),
+                                 (123, None, '?user-id=123'),
                                  (None, 2, '?page=2'),
-                                 (123, 2, '?user_id=123&page=2'),
+                                 (123, 2, '?user-id=123&page=2'),
                              ))
     def test_find_projects(self, data_client, rmock, user_id, page, expected_query_string):
         rmock.get('/direct-award/projects{}'.format(expected_query_string),
@@ -2183,7 +2183,7 @@ class TestDataApiClient(object):
         assert result == {"project": "ok"}
 
     def test_get_project(self, data_client, rmock):
-        rmock.get('/direct-award/projects/1?user_id=123',
+        rmock.get('/direct-award/projects/1?user-id=123',
                   json={"project": "ok"},
                   status_code=200)
 
@@ -2204,7 +2204,7 @@ class TestDataApiClient(object):
         assert rmock.last_request.json() == {
             "project": {
                 "name": "my project",
-                "user_id": 123
+                "userId": 123
             },
             "updated_by": "user@email.com"
         }
@@ -2212,9 +2212,9 @@ class TestDataApiClient(object):
     @pytest.mark.parametrize('user_id, page, expected_query_string',
                              (
                                  (None, None, ''),
-                                 (123, None, '?user_id=123'),
+                                 (123, None, '?user-id=123'),
                                  (None, 2, '?page=2'),
-                                 (123, 2, '?user_id=123&page=2'),
+                                 (123, 2, '?user-id=123&page=2'),
                              ))
     def test_find_project_searches(self, data_client, rmock, user_id, page, expected_query_string):
         rmock.get('/direct-award/projects/1/searches{}'.format(expected_query_string),
@@ -2237,14 +2237,14 @@ class TestDataApiClient(object):
         assert result == {"search": "result"}
         assert rmock.last_request.json() == {
             "search": {
-                "search_url": "search-url",
-                "user_id": 123
+                "searchUrl": "search-url",
+                "userId": 123
             },
             "updated_by": "user@email.com"
         }
 
     def test_get_project_search(self, data_client, rmock):
-        rmock.get('/direct-award/projects/1/searches/2?user_id=123',
+        rmock.get('/direct-award/projects/1/searches/2?user-id=123',
                   json={"search": "ok"},
                   status_code=200)
 
@@ -2406,7 +2406,7 @@ class TestDataAPIClientIterMethods(object):
 
     def test_find_direct_award_project_searches_iter(self, data_client, rmock):
         rmock.get(
-            'http://baseurl/direct-award/projects/1/searches?user_id=123',
+            'http://baseurl/direct-award/projects/1/searches?user-id=123',
             json={
                 'links': {},
                 'searches': [{'id': 1}, {'id': 2}]


### PR DESCRIPTION
## Summary
Update api client to use adjusted query params, JSON formats, etc for Direct Award based on feedback from code review. Query params = snake case, JSON data = camel case.
Bump version to 9.1.1