### PR TITLE
Save a search and create a project

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '9.1.1'
+__version__ = '9.2.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/search.py
+++ b/dmapiclient/search.py
@@ -52,7 +52,7 @@ class SearchAPIClient(BaseAPIClient):
 
         return self._build_url(url=self._url(index=index, path=path), params=params)
 
-    def deconstruct_url(self, search_api_url):
+    def get_frontend_params_from_search_api_url(self, search_api_url):
         """
         Converts a searchAPI url to url params a frontend understands
         :param search_api_url: Fully qualified searchAPI url
@@ -64,10 +64,10 @@ class SearchAPIClient(BaseAPIClient):
 
         return frontend_params
 
-    def get_search_url(self, index, q='', page=None, **filters):
+    def get_search_url(self, index, q=None, page=None, **filters):
         return self.get_url(path='search', index=index, q=q, page=page, **filters)
 
-    def get_aggregations_url(self, index, q='', aggregations=[], **filters):
+    def get_aggregations_url(self, index, q=None, aggregations=[], **filters):
         return self.get_url(path='aggregations', index=index, q=q, aggregations=aggregations, **filters)
 
     def create_index(self, index):

--- a/dmapiclient/search.py
+++ b/dmapiclient/search.py
@@ -1,5 +1,9 @@
 import six
-from urllib.parse import urlparse, parse_qsl
+try:
+    from urllib.parse import urlparse, parse_qsl
+except ImportError:
+    from urlparse import urlparse, parse_qsl
+
 
 from .base import BaseAPIClient
 from .errors import HTTPError
@@ -91,8 +95,6 @@ class SearchAPIClient(BaseAPIClient):
             if e.status_code != 404:
                 raise
         return None
-
-
 
     def search_services(self, index, q=None, page=None, **filters):
         response = self._get(self.get_search_url(index=index,

--- a/dmapiclient/search.py
+++ b/dmapiclient/search.py
@@ -1,4 +1,5 @@
 import six
+from urllib.parse import urlparse, parse_qsl
 
 from .base import BaseAPIClient
 from .errors import HTTPError
@@ -13,6 +14,26 @@ class SearchAPIClient(BaseAPIClient):
     def _url(self, index, path):
         return u"/{}/services/{}".format(index, path)
 
+    def _add_filters_prefix_to_params(self, params, filters):
+        """In-place transformation of filter keys and storage in params."""
+        for filter_name, filter_values in six.iteritems(filters):
+            params[u'filter_{}'.format(filter_name)] = filter_values
+
+    def _remove_filters_prefix_from_params(self, search_api_params):
+        """
+        Convert searchAPI url parameters to frontend url parameters by removing filter_ prefix from url parameters
+        :param search_api_params: list of two item tuples
+        :return: list of two item tuples
+        """
+        frontend_params = []
+        for filter_name, filter_value in search_api_params:
+            if filter_name.startswith('filter_'):
+                frontend_params.append((filter_name[7:], filter_value))
+            else:
+                frontend_params.append((filter_name, filter_value))
+
+        return frontend_params
+
     def get_url(self, path, index, q, page=None, aggregations=[], **filters):
         params = {}
         if q is not None:
@@ -23,9 +44,21 @@ class SearchAPIClient(BaseAPIClient):
         elif page:
             params['page'] = page
 
-        self._add_filters_to_params(params, filters)
+        self._add_filters_prefix_to_params(params, filters)
 
         return self._build_url(url=self._url(index=index, path=path), params=params)
+
+    def deconstruct_url(self, search_api_url):
+        """
+        Converts a searchAPI url to url params a frontend understands
+        :param search_api_url: Fully qualified searchAPI url
+        :return: list of two item tuples [(param_name, param_value), ...]
+        """
+        url = urlparse(search_api_url)
+        query = parse_qsl(url.query)
+        frontend_params = self._remove_filters_prefix_from_params(query)
+
+        return frontend_params
 
     def get_search_url(self, index, q='', page=None, **filters):
         return self.get_url(path='search', index=index, q=q, page=page, **filters)
@@ -59,16 +92,14 @@ class SearchAPIClient(BaseAPIClient):
                 raise
         return None
 
-    def _add_filters_to_params(self, params, filters):
-        """In-place transformation of filter keys and storage in params."""
-        for filter_name, filter_values in six.iteritems(filters):
-            params[u'filter_{}'.format(filter_name)] = filter_values
+
 
     def search_services(self, index, q=None, page=None, **filters):
         response = self._get(self.get_search_url(index=index,
                                                  q=q,
                                                  page=page,
                                                  **filters))
+
         return response
 
     def aggregate_services(self, index, q=None, aggregations=[], **filters):

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -376,7 +376,7 @@ class TestSearchApiClient(object):
                                  ('http://localhost/search?filter_phoneSupport=true', [('phoneSupport', 'true')]),
                                  ('http://localhost/search?filter_governmentSecurityClearances=dv%2Csc',
                                   [('governmentSecurityClearances', 'dv,sc')]),
-                                 ('http://localhost/search?filter_userAuthentication=two_factor&filter_userAuthenticat'\
+                                 ('http://localhost/search?filter_userAuthentication=two_factor&filter_userAuthenticat'
                                   'ion=pka', [('userAuthentication', 'two_factor'), ('userAuthentication', 'pka')])
                               ))
     def test_deconstruct_url(self, search_client, rmock, search_api_url, expected_frontend_params):

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -379,8 +379,9 @@ class TestSearchApiClient(object):
                                  ('http://localhost/search?filter_userAuthentication=two_factor&filter_userAuthenticat'
                                   'ion=pka', [('userAuthentication', 'two_factor'), ('userAuthentication', 'pka')])
                               ))
-    def test_deconstruct_url(self, search_client, rmock, search_api_url, expected_frontend_params):
-        assert search_client.deconstruct_url(search_api_url) == expected_frontend_params
+    def test_get_frontend_params_from_search_api_url(self, search_client, rmock, search_api_url,
+                                                     expected_frontend_params):
+        assert search_client.get_frontend_params_from_search_api_url(search_api_url) == expected_frontend_params
 
 
 class TestDataApiClient(object):

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -369,6 +369,19 @@ class TestSearchApiClient(object):
         with open(file_path) as f:
             return json.load(f)
 
+    @pytest.mark.parametrize('search_api_url, expected_frontend_params',
+                             (
+                                 ('http://localhost/search', []),
+                                 ('http://localhost/search?lot=cloud-hosting', [('lot', 'cloud-hosting')]),
+                                 ('http://localhost/search?filter_phoneSupport=true', [('phoneSupport', 'true')]),
+                                 ('http://localhost/search?filter_governmentSecurityClearances=dv%2Csc',
+                                  [('governmentSecurityClearances', 'dv,sc')]),
+                                 ('http://localhost/search?filter_userAuthentication=two_factor&filter_userAuthenticat'\
+                                  'ion=pka', [('userAuthentication', 'two_factor'), ('userAuthentication', 'pka')])
+                              ))
+    def test_deconstruct_url(self, search_client, rmock, search_api_url, expected_frontend_params):
+        assert search_client.deconstruct_url(search_api_url) == expected_frontend_params
+
 
 class TestDataApiClient(object):
     def test_request_id_is_added_if_available(self, data_client, rmock, app):

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -383,6 +383,12 @@ class TestSearchApiClient(object):
                                                      expected_frontend_params):
         assert search_client.get_frontend_params_from_search_api_url(search_api_url) == expected_frontend_params
 
+    def test_get_search_url(self, search_client):
+        assert search_client.get_search_url('g-cloud-9') == 'http://baseurl/g-cloud-9/services/search'
+
+    def test_get_aggregations_url(self, search_client):
+        assert search_client.get_aggregations_url('g-cloud-9') == 'http://baseurl/g-cloud-9/services/aggregations'
+
 
 class TestDataApiClient(object):
     def test_request_id_is_added_if_available(self, data_client, rmock, app):


### PR DESCRIPTION
## Summary

* Adding a new method to turn the search api url into frontend url
* Bump version to 9.2.0
* Also found a bug with two previously implemented methods for getting search/aggregation URLs whereby it would include the `q` parameter by default if not supplied. Made sure this doesn't happen and pinned it with two tests.

## Ticket
https://trello.com/c/Hlq5mzAy/619-save-a-search-and-create-a-project