### PR TITLE
Update Brief status to cancelled or unsuccessful

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '10.0.0'
+__version__ = '10.1.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -628,6 +628,20 @@ class DataAPIClient(BaseAPIClient):
             user=user,
         )
 
+    def cancel_brief(self, brief_id, user):
+        return self._post_with_updated_by(
+            "/briefs/{}/cancel".format(brief_id),
+            data={},
+            user=user,
+        )
+
+    def update_brief_as_unsuccessful(self, brief_id, user):
+        return self._post_with_updated_by(
+            "/briefs/{}/unsuccessful".format(brief_id),
+            data={},
+            user=user,
+        )
+
     def get_brief(self, brief_id):
         return self._get(
             "/briefs/{}".format(brief_id))

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1897,6 +1897,34 @@ class TestDataApiClient(object):
             "updated_by": "user@email.com"
         }
 
+    def test_cancel_brief(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/briefs/123/cancel",
+            json={"briefs": "result"},
+            status_code=200,
+        )
+
+        result = data_client.cancel_brief(123, "user@email.com")
+
+        assert result == {"briefs": "result"}
+        assert rmock.last_request.json() == {
+            "updated_by": "user@email.com"
+        }
+
+    def test_update_brief_as_unsuccessful(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/briefs/123/unsuccessful",
+            json={"briefs": "result"},
+            status_code=200,
+        )
+
+        result = data_client.update_brief_as_unsuccessful(123, "user@email.com")
+
+        assert result == {"briefs": "result"}
+        assert rmock.last_request.json() == {
+            "updated_by": "user@email.com"
+        }
+
     def test_get_brief(self, data_client, rmock):
         rmock.get(
             "http://baseurl/briefs/123",


### PR DESCRIPTION
Trello ticket: https://trello.com/c/ggDGUY5d/823-2-collect-status-when-a-buyer-is-not-proceeding-with-an-award-no-journey-backend

New API client methods to pass the new `cancelled` and `unsuccessful` statuses to the same existing API route `update_brief_status` (which at present just accepts `publish` and `withdraw` - this will be changed in the API very shortly!).