### PR TITLE
Remove unused param from get_direct_award_project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 Records breaking changes from major version bumps
 
+## 10.0.0
+
+PR: [#90](https://github.com/alphagov/digitalmarketplace-apiclient/pull/90)
+
+Removes an unused parameter from the get_direct_award_project endpint.
+
+Old
+```python
+data_api_client.get_direct_award_project(user_id=123, project_id=123)
+```
+
+New
+```python
+data_api_client.get_direct_award_project(project_id=123)
+```
+
+
 ## 9.0.0
 
 PR: [#86](https://github.com/alphagov/digitalmarketplace-apiclient/pull/86)

--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '9.2.0'
+__version__ = '10.0.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -792,10 +792,8 @@ class DataAPIClient(BaseAPIClient):
 
     find_direct_award_projects_iter = make_iter_method('find_direct_award_projects', 'projects')
 
-    def get_direct_award_project(self, user_id, project_id):
-        return self._get(
-            "/direct-award/projects/{}".format(project_id),
-            params={"user-id": user_id})
+    def get_direct_award_project(self, project_id):
+        return self._get("/direct-award/projects/{}".format(project_id))
 
     def create_direct_award_project(self, user_id, user_email, project_name):
         return self._post_with_updated_by(

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -2203,11 +2203,11 @@ class TestDataApiClient(object):
         assert result == {"project": "ok"}
 
     def test_get_project(self, data_client, rmock):
-        rmock.get('/direct-award/projects/1?user-id=123',
+        rmock.get('/direct-award/projects/1',
                   json={"project": "ok"},
                   status_code=200)
 
-        result = data_client.get_direct_award_project(user_id=123, project_id=1)
+        result = data_client.get_direct_award_project(project_id=1)
         assert result == {"project": "ok"}
 
     def test_create_project(self, data_client, rmock):


### PR DESCRIPTION
## Summary
`user-id` was being passed to the `get_direct_award_project` endpoint, but the API just ignores this. So let's remove it. And bump version to 10.0.0