### PR TITLE
Get index from search api url

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '10.1.0'
+__version__ = '10.2.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/search.py
+++ b/dmapiclient/search.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+
+import re
 import six
 try:
     from urllib.parse import urlparse, parse_qsl
@@ -17,6 +20,15 @@ class SearchAPIClient(BaseAPIClient):
 
     def _url(self, index, path):
         return u"/{}/services/{}".format(index, path)
+
+    def _url_reverse(self, url):
+        url = urlparse(url)
+        try:
+            index, path = re.match(r'^/(?P<index>.+)/services/(?P<path>.+)$', url.path).groups()
+        except AttributeError:
+            return None, None
+        else:
+            return index, path
 
     def _add_filters_prefix_to_params(self, params, filters):
         """In-place transformation of filter keys and storage in params."""
@@ -63,6 +75,9 @@ class SearchAPIClient(BaseAPIClient):
         frontend_params = self._remove_filters_prefix_from_params(query)
 
         return frontend_params
+
+    def get_index_from_search_api_url(self, search_api_url):
+        return self._url_reverse(search_api_url)[0]
 
     def get_search_url(self, index, q=None, page=None, **filters):
         return self.get_url(path='search', index=index, q=q, page=page, **filters)

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -389,6 +389,17 @@ class TestSearchApiClient(object):
     def test_get_aggregations_url(self, search_client):
         assert search_client.get_aggregations_url('g-cloud-9') == 'http://baseurl/g-cloud-9/services/aggregations'
 
+    @pytest.mark.parametrize('search_api_url, expected_index',
+                             (
+                                 ('http://localhost/g-cloud-8/services/search', 'g-cloud-8'),
+                                 ('http://localhost/g-cloud-9/services/search', 'g-cloud-9'),
+                                 ('https://search-api.preview.marketplace.team/g-cloud-9/services/search', 'g-cloud-9'),
+                                 ('https://search-api.preview.marketplace.team/g-cloud-8/services/search', 'g-cloud-8'),
+                                 ('https://some.broken.url.com/that/does/not/match', None)
+                             ))
+    def test_get_index_from_search_api_url(self, search_client, search_api_url, expected_index):
+        assert search_client.get_index_from_search_api_url(search_api_url) == expected_index
+
 
 class TestDataApiClient(object):
     def test_request_id_is_added_if_available(self, data_client, rmock, app):


### PR DESCRIPTION
## Summary
To display the search overview page correctly we need to know what framework instance the search relates do. We know this from the search API URL which includes the framework slug. Therefore, we need to be able to extract the slug from the API URL. This adds a method on the search API client to do this.

Bumps version to 10.2.0.

## Ticket
https://trello.com/c/9YtT8DmX/675-task-list-saved-search-overview-page