### PR TITLE
Lock projects and get all services by Search API URL

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '10.2.0'
+__version__ = '10.3.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/audit.py
+++ b/dmapiclient/audit.py
@@ -63,6 +63,7 @@ class AuditTypes(Enum):
     # Projects
     create_project = "create_project"
     create_project_search = "create_project_search"
+    lock_project = "lock_project"
 
     @staticmethod
     def is_valid_audit_type(test_audit_type):

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -854,3 +854,10 @@ class DataAPIClient(BaseAPIClient):
 
     def find_direct_award_project_services(self, user_id, project_id):
         raise NotImplementedError()
+
+    def lock_direct_award_project(self, user_email, project_id):
+        return self._post_with_updated_by(
+            "/direct-award/projects/{}/lock".format(project_id),
+            data={},
+            user=user_email,
+        )


### PR DESCRIPTION
## Summary
Adds a new method to the DataAPIClient to lock a Direct Award Project, and a new method (+ `_iter`) to the SearchAPIClient to retrieve services from a given Search API URL.
Bumps the version to 10.3.0

## Ticket
https://trello.com/c/gs2I3Cj2/676-end-your-search