### PR TITLE
Add `unlock_user` argument flag to `.update_user_password`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 Records breaking changes from major version bumps
 
+## 11.0.0
+
+PR: [#93](https://github.com/alphagov/digitalmarketplace-apiclient/pull/93)
+
+### What changed
+
+`DataApiClient.update_user_password` now has an additional `unlock_user` argument. When set to `True` it will unlock the user (clear the "5 failed login attempts") as well as reset the password.
+
+### Example app change
+
+Old
+```python
+api_client.update_user_password(1, 'newpassword', 'updater-email@example.com')
+```
+
+New
+
+```python
+api_client.update_user_password(1, 'newpassword', updater='updater-email@example.com')
+```
+
+```python
+api_client.update_user_password(1, 'newpassword', unlock_user=True, updater='updater-email@example.com')
+```
+
+
 ## 10.0.0
 
 PR: [#90](https://github.com/alphagov/digitalmarketplace-apiclient/pull/90)

--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '10.3.0'
+__version__ = '11.0.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -357,17 +357,19 @@ class DataAPIClient(BaseAPIClient):
             if e.status_code not in [400, 403, 404]:
                 raise
 
-    def update_user_password(self, user_id, new_password, updater="no logged-in user"):
+    def update_user_password(self, user_id, new_password, unlock_user=False, updater="no logged-in user"):
+        user_fields = {"password": new_password}
+        if unlock_user:
+            user_fields['locked'] = False
+
         try:
             self._post_with_updated_by(
                 '/users/{}'.format(user_id),
-                data={
-                    "users": {"password": new_password},
-                },
+                data={"users": user_fields},
                 user=updater,
             )
             return True
-        except HTTPError as e:
+        except HTTPError:
             return False
 
     def update_user(self,
@@ -408,8 +410,8 @@ class DataAPIClient(BaseAPIClient):
             user=updater,
         )
 
-        logger.info("Updated user {user_id} fields {params}",
-                    extra={"user_id": user_id, "params": params})
+        logger.info("Updated user {user_id} fields: {params}",
+                    extra={"user_id": user_id, "params": u", ".join(u"{}={}".format(k, v) for k, v in params.items())})
         return user
 
     def export_users(self, framework_slug):

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -730,10 +730,25 @@ class TestDataApiClient(object):
             "http://baseurl/users/123",
             json={},
             status_code=200)
-        assert data_client.update_user_password(123, "newpassword", "test@example.com")
+        assert data_client.update_user_password(123, "newpassword", updater="test@example.com")
         assert rmock.last_request.json() == {
             "users": {
                 "password": "newpassword"
+            },
+            "updated_by": "test@example.com"
+        }
+
+    def test_update_user_password_and_unlock_user(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/users/123",
+            json={},
+            status_code=200)
+        assert data_client.update_user_password(123, "newpassword", unlock_user=True, updater="test@example.com")
+        assert rmock.last_request.json() == {
+            "users": {
+                "password": "newpassword",
+                "locked": False
+
             },
             "updated_by": "test@example.com"
         }


### PR DESCRIPTION
Allows unlocking the user and resetting the failed login count when
the password is changed.

Since password update is the same endpoint as the user update it makes
sense to do both changes in one API request to avoid any inconsistencies
that could be caused by one of the requests failing.

Updater details are the last argument for most API client methods, so
I'm adding a new argument before `updater`, making this a breaking
change. This shouldn't be an issue in practice since the method is
currently only used by the user-frontend.