### PR TITLE
Add "IDs only" option to search services

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '10.4.0'
+__version__ = '10.5.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa


### PR DESCRIPTION
## Summary
When we lock Direct Award projects (at the 'end search' stage), we need to record all the service IDs that matched for the given search.
Bump version to 10.5.0.
Remove some 'helper' functions that exist for no real reason (get_search_url/get_aggregations_url)

## Ticket
https://trello.com/c/gs2I3Cj2/676-end-your-search