### PR TITLE
Support only-active parameter for list searches endpoint

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '10.5.0'
+__version__ = '10.6.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -821,13 +821,18 @@ class DataAPIClient(BaseAPIClient):
             user=user_email
         )
 
-    def find_direct_award_project_searches(self, user_id, project_id, page=None):
+    def find_direct_award_project_searches(self, user_id, project_id, page=None, only_active=None):
+        params = {
+                "user-id": user_id,
+                "page": page,
+        }
+
+        if only_active is not None:
+            params.update({'only-active': only_active})
+
         return self._get(
             "/direct-award/projects/{}/searches".format(project_id),
-            params={
-                "user-id": user_id,
-                "page": page
-            }
+            params=params
         )
 
     find_direct_award_project_searches_iter = make_iter_method('find_direct_award_project_searches', 'projects')

--- a/dmapiclient/search.py
+++ b/dmapiclient/search.py
@@ -83,6 +83,9 @@ class SearchAPIClient(BaseAPIClient):
     def get_index_from_search_api_url(self, search_api_url):
         return self._url_reverse(search_api_url)[0]
 
+    def get_search_url(self, index, q=None, page=None, **filters):
+        return self.get_url(path='search', index=index, q=q, page=page, **filters)
+
     def create_index(self, index):
         return self._put(
             '/{}'.format(index),
@@ -110,7 +113,7 @@ class SearchAPIClient(BaseAPIClient):
         return None
 
     def search_services(self, index, q=None, page=None, id_only=False, **filters):
-        response = self._get(self.get_url(path='search', index=index, q=q, page=page, id_only=id_only, **filters))
+        response = self._get(self.get_search_url(index=index, q=q, page=page, id_only=id_only, **filters))
         return response
 
     def search_services_from_url(self, search_api_url, id_only=False, page=None):

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -2304,19 +2304,23 @@ class TestDataApiClient(object):
             "updated_by": "user@email.com"
         }
 
-    @pytest.mark.parametrize('user_id, page, expected_query_string',
+    @pytest.mark.parametrize('user_id, page, active, expected_query_string',
                              (
-                                 (None, None, ''),
-                                 (123, None, '?user-id=123'),
-                                 (None, 2, '?page=2'),
-                                 (123, 2, '?user-id=123&page=2'),
+                                 (None, None, None, ''),
+                                 (None, None, True, '?only-active=True'),
+                                 (None, None, False, '?only-active=False'),
+                                 (123, None, None, '?user-id=123'),
+                                 (None, 2, None, '?page=2'),
+                                 (None, 2, False, '?page=2&only-active=False'),
+                                 (123, 2, True, '?user-id=123&page=2&only-active=True'),
                              ))
-    def test_find_direct_award_project_searches(self, data_client, rmock, user_id, page, expected_query_string):
+    def test_find_direct_award_project_searches(self, data_client, rmock, user_id, page, active, expected_query_string):
         rmock.get('/direct-award/projects/1/searches{}'.format(expected_query_string),
                   json={"searches": "ok"},
                   status_code=200)
 
-        result = data_client.find_direct_award_project_searches(user_id=user_id, project_id=1, page=page)
+        result = data_client.find_direct_award_project_searches(user_id=user_id, project_id=1, page=page,
+                                                                only_active=active)
         assert result == {"searches": "ok"}
 
     def test_create_direct_award_project_search(self, data_client, rmock):

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -402,6 +402,9 @@ class TestSearchApiClient(object):
         expected_url = 'http://baseurl/{}/services/{}'.format(index, path)
         assert search_client.get_url(path=path, index=index, q=None) == expected_url
 
+    def test_get_search_url(self, search_client):
+        assert search_client.get_search_url('g-cloud-9') == 'http://baseurl/g-cloud-9/services/search'
+
     @pytest.mark.parametrize('search_api_url, expected_index',
                              (
                                  ('http://localhost/g-cloud-8/services/search', 'g-cloud-8'),


### PR DESCRIPTION
## Summary
Retrieve only active searches from a direct award project. At the moment we enforce only one search active at a time, but given this is a common usecase it is still useful to have a way of only returning the active search as all frontend calls just ignore inactive searches at the moment.
Add back in that get_search_url method that I thought was useless but was obviously part of a public interface.
Bump version to 10.6.0.

## Ticket
https://trello.com/c/igRhA3Bt/711-shortlist-file-download