### PR TITLE
Get Direct Award Project services

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '10.6.0'
+__version__ = '10.7.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/audit.py
+++ b/dmapiclient/audit.py
@@ -64,6 +64,7 @@ class AuditTypes(Enum):
     create_project = "create_project"
     create_project_search = "create_project_search"
     lock_project = "lock_project"
+    downloaded_project = "downloaded_project"
 
     # Mailing list actions
     mailing_list_subscription = "mailing_list_subscription"

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -874,3 +874,10 @@ class DataAPIClient(BaseAPIClient):
             data={},
             user=user_email,
         )
+
+    def record_direct_award_project_download(self, user_email, project_id):
+        return self._post_with_updated_by(
+            "/direct-award/projects/{}/record-download".format(project_id),
+            data={},
+            user=user_email,
+        )

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -857,8 +857,16 @@ class DataAPIClient(BaseAPIClient):
             }
         )
 
-    def find_direct_award_project_services(self, user_id, project_id):
-        raise NotImplementedError()
+    def get_direct_award_project_services(self, user_id, project_id, fields=[]):
+        return self._get(
+            "/direct-award/projects/{}/services".format(project_id),
+            params={
+                "user-id": user_id,
+                "fields": ','.join(fields)
+            }
+        )
+
+    get_direct_award_project_services_iter = make_iter_method('get_direct_award_project_services', 'services')
 
     def lock_direct_award_project(self, user_email, project_id):
         return self._post_with_updated_by(

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -2532,9 +2532,35 @@ class TestDataAPIClientIterMethods(object):
         assert set(result.keys()) == {'links', 'searches'}
         assert len(result['searches']) == 2
 
-    def test_find_direct_award_project_services(self, data_client, rmock):
-        with pytest.raises(NotImplementedError):
-            data_client.find_direct_award_project_services(user_id=123, project_id=1)
+    def test_get_direct_award_project_services(self, data_client, rmock):
+        rmock.get('/direct-award/projects/1/services?user-id=123',
+                  json={"services": "ok"},
+                  status_code=200)
+
+        result = data_client.get_direct_award_project_services(user_id=123, project_id=1)
+        assert result == {"services": "ok"}
+
+    def test_get_direct_award_project_services_specific_fields(self, data_client, rmock):
+        rmock.get('/direct-award/projects/1/services?user-id=123&fields=id,price',
+                  json={"services": "ok"},
+                  status_code=200)
+
+        result = data_client.get_direct_award_project_services(user_id=123, project_id=1, fields=['id', 'price'])
+        assert result == {"services": "ok"}
+
+    def test_get_direct_award_project_services_iter(self, data_client, rmock):
+        rmock.get(
+            'http://baseurl/direct-award/projects/1/services?user-id=123',
+            json={
+                'links': {},
+                'services': [{'id': 1}, {'id': 2}]
+            },
+            status_code=200)
+
+        result = data_client.get_direct_award_project_services(user_id=123, project_id=1)
+
+        assert set(result.keys()) == {'links', 'services'}
+        assert len(result['services']) == 2
 
 
 class TestSearchAPIClientIterMethods(object):

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -2365,6 +2365,18 @@ class TestDataApiClient(object):
             "updated_by": "user@email.com"
         }
 
+    def test_record_direct_award_project_download(self, data_client, rmock):
+        rmock.post('/direct-award/projects/1/record-download',
+                   json={"project": "ok"},
+                   status_code=200)
+
+        result = data_client.record_direct_award_project_download(user_email="user@email.com", project_id=1)
+
+        assert result == {"project": "ok"}
+        assert rmock.last_request.json() == {
+            "updated_by": "user@email.com"
+        }
+
 
 class TestDataAPIClientIterMethods(object):
     def _test_find_iter(self, data_client, rmock, method_name, model_name, url_path):


### PR DESCRIPTION
## Summary
Implements the apiclient methods to get Direct Award Project services and to record the download of search results.

Adds a new AuditEvent type for downloading search results.

Bumps the version to 10.7.0.

## Required by
https://github.com/alphagov/digitalmarketplace-api/pull/656
https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/615

## Other associated PRs
https://github.com/alphagov/digitalmarketplace-utils/pull/332
https://github.com/alphagov/digitalmarketplace-frameworks/pull/473
https://github.com/alphagov/digitalmarketplace-briefs-frontend/pull/32

## Ticket
https://trello.com/c/igRhA3Bt/711-shortlist-file-download