### PR TITLE
Deduplicate test fixture rmock into conftest file

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,24 @@
 import pytest
+import requests_mock
 from flask import Flask
 
 
 @pytest.fixture
 def app():
     return Flask(__name__)
+
+
+@pytest.yield_fixture
+def rmock():
+    with requests_mock.mock() as rmock:
+        real_register_uri = rmock.register_uri
+
+        def register_uri_with_complete_qs(*args, **kwargs):
+            if 'complete_qs' not in kwargs:
+                kwargs['complete_qs'] = True
+
+            return real_register_uri(*args, **kwargs)
+
+        rmock.register_uri = register_uri_with_complete_qs
+
+        yield rmock

--- a/tests/test_base_api_client.py
+++ b/tests/test_base_api_client.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import requests
-import requests_mock
 import pytest
 import mock
 
@@ -9,22 +8,6 @@ from dmapiclient import HTTPError, InvalidResponse
 from dmapiclient.errors import REQUEST_ERROR_STATUS_CODE
 from dmapiclient.errors import REQUEST_ERROR_MESSAGE
 from dmapiclient.exceptions import ImproperlyConfigured
-
-
-@pytest.yield_fixture
-def rmock():
-    with requests_mock.mock() as rmock:
-        real_register_uri = rmock.register_uri
-
-        def register_uri_with_complete_qs(*args, **kwargs):
-            if 'complete_qs' not in kwargs:
-                kwargs['complete_qs'] = True
-
-            return real_register_uri(*args, **kwargs)
-
-        rmock.register_uri = register_uri_with_complete_qs
-
-        yield rmock
 
 
 @pytest.yield_fixture

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -1,28 +1,11 @@
 # -*- coding: utf-8 -*-
 from flask import json, request
-import requests_mock
 import pytest
 import mock
 
 from dmapiclient import DataAPIClient
 from dmapiclient import APIError, HTTPError
 from dmapiclient.audit import AuditTypes
-
-
-@pytest.yield_fixture
-def rmock():
-    with requests_mock.mock() as rmock:
-        real_register_uri = rmock.register_uri
-
-        def register_uri_with_complete_qs(*args, **kwargs):
-            if 'complete_qs' not in kwargs:
-                kwargs['complete_qs'] = True
-
-            return real_register_uri(*args, **kwargs)
-
-        rmock.register_uri = register_uri_with_complete_qs
-
-        yield rmock
 
 
 @pytest.fixture

--- a/tests/test_search_api_client.py
+++ b/tests/test_search_api_client.py
@@ -2,28 +2,11 @@
 import os
 
 from flask import json
-import requests_mock
 import pytest
 import mock
 
 from dmapiclient import SearchAPIClient
 from dmapiclient import APIError, HTTPError
-
-
-@pytest.yield_fixture
-def rmock():
-    with requests_mock.mock() as rmock:
-        real_register_uri = rmock.register_uri
-
-        def register_uri_with_complete_qs(*args, **kwargs):
-            if 'complete_qs' not in kwargs:
-                kwargs['complete_qs'] = True
-
-            return real_register_uri(*args, **kwargs)
-
-        rmock.register_uri = register_uri_with_complete_qs
-
-        yield rmock
 
 
 @pytest.fixture


### PR DESCRIPTION
@katstevens Meant to comment about this on the PR but was too late. To make a fixture available to all tests just stick it in the `conftest.py`
https://docs.pytest.org/en/latest/fixture.html#sharing-a-fixture-across-tests-in-a-module-or-class-session