### PR TITLE
Update for saved search data tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 Records breaking changes from major version bumps
 
+## 11.0.0
+
+PR: [#105](https://github.com/alphagov/digitalmarketplace-apiclient/pull/105)
+
+Gives `user_id` parameter a default for `find_direct_award_project_searches` and `get_direct_award_project_services`,
+which changes the order of their positional parameters.
+
+The old/new examples below are calling the methods with no `user_id` and a `project_id` of 123.
+
+Old
+```
+data_api_client.get_direct_award_project_services(None, 123)
+data_api_client.find_direct_award_project_searches(None, 123)
+```
+
+New
+```
+data_api_client.get_direct_award_project_services(123)
+data_api_client.find_direct_award_project_searches(123)
+```
+
+
 ## 10.0.0
 
 PR: [#90](https://github.com/alphagov/digitalmarketplace-apiclient/pull/90)

--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '10.9.0'
+__version__ = '11.0.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -851,7 +851,7 @@ class DataAPIClient(BaseAPIClient):
             params=params
         )
 
-    find_direct_award_project_searches_iter = make_iter_method('find_direct_award_project_searches', 'projects')
+    find_direct_award_project_searches_iter = make_iter_method('find_direct_award_project_searches', 'searches')
 
     def create_direct_award_project_search(self, user_id, user_email, project_id, search_url):
         return self._post_with_updated_by(

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -837,7 +837,7 @@ class DataAPIClient(BaseAPIClient):
             user=user_email
         )
 
-    def find_direct_award_project_searches(self, user_id, project_id, page=None, only_active=None):
+    def find_direct_award_project_searches(self, project_id, user_id=None, page=None, only_active=None):
         params = {
             "user-id": user_id,
             "page": page,
@@ -873,13 +873,14 @@ class DataAPIClient(BaseAPIClient):
             }
         )
 
-    def get_direct_award_project_services(self, user_id, project_id, fields=[]):
+    def get_direct_award_project_services(self, project_id, user_id=None, fields=[]):
+        params = {"user-id": user_id}
+        if fields:
+            params.update({"fields": ','.join(fields)})
+
         return self._get(
             "/direct-award/projects/{}/services".format(project_id),
-            params={
-                "user-id": user_id,
-                "fields": ','.join(fields)
-            }
+            params=params
         )
 
     get_direct_award_project_services_iter = make_iter_method('get_direct_award_project_services', 'services')

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -804,7 +804,7 @@ class DataAPIClient(BaseAPIClient):
 
     # Direct Award Projects
 
-    def find_direct_award_projects(self, user_id=None, page=None, latest_first=None):
+    def find_direct_award_projects(self, user_id=None, page=None, latest_first=None, with_users=False):
         params = {
             "user-id": user_id,
             "page": page
@@ -812,6 +812,8 @@ class DataAPIClient(BaseAPIClient):
 
         if latest_first is not None:
             params['latest-first'] = latest_first
+        if with_users:
+            params['include'] = "users"
 
         return self._get(
             "/direct-award/projects",

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -885,6 +885,9 @@ class DataAPIClient(BaseAPIClient):
 
     get_direct_award_project_services_iter = make_iter_method('get_direct_award_project_services', 'services')
 
+    # This is here to maintain compatability with the ModelTrawler class used by the get-model-data script.
+    find_direct_award_project_services_iter = get_direct_award_project_services_iter
+
     def lock_direct_award_project(self, user_email, project_id):
         return self._post_with_updated_by(
             "/direct-award/projects/{}/lock".format(project_id),

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -2166,11 +2166,11 @@ class TestDataAPIClientIterMethods(object):
         assert len(result['searches']) == 2
 
     def test_get_direct_award_project_services(self, data_client, rmock):
-        rmock.get('/direct-award/projects/1/services?user-id=123',
+        rmock.get('/direct-award/projects/1/services',
                   json={"services": "ok"},
                   status_code=200)
 
-        result = data_client.get_direct_award_project_services(user_id=123, project_id=1)
+        result = data_client.get_direct_award_project_services(project_id=1)
         assert result == {"services": "ok"}
 
     def test_get_direct_award_project_services_specific_fields(self, data_client, rmock):
@@ -2183,14 +2183,14 @@ class TestDataAPIClientIterMethods(object):
 
     def test_get_direct_award_project_services_iter(self, data_client, rmock):
         rmock.get(
-            'http://baseurl/direct-award/projects/1/services?user-id=123',
+            'http://baseurl/direct-award/projects/1/services',
             json={
                 'links': {},
                 'services': [{'id': 1}, {'id': 2}]
             },
             status_code=200)
 
-        result = data_client.get_direct_award_project_services(user_id=123, project_id=1)
+        result = data_client.get_direct_award_project_services(project_id=1)
 
         assert set(result.keys()) == {'links', 'services'}
         assert len(result['services']) == 2

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -1880,21 +1880,25 @@ class TestFrameworkAgreementMethods(object):
 
 
 class TestDirectAwardMethods(object):
-    @pytest.mark.parametrize('user_id, page, latest_first, expected_query_string',
+    @pytest.mark.parametrize('user_id, page, latest_first, with_users, expected_query_string',
                              (
-                                 (None, None, None, ''),
-                                 (123, None, None, '?user-id=123'),
-                                 (None, 2, None, '?page=2'),
-                                 (None, None, True, '?latest-first=True'),
-                                 (123, 2, None, '?user-id=123&page=2'),
-                                 (123, 2, False, '?user-id=123&page=2&latest-first=False'),
+                                 (None, None, None, None, ''),
+                                 (123, None, None, False, '?user-id=123'),
+                                 (None, 2, None, False, '?page=2'),
+                                 (None, None, True, False, '?latest-first=True'),
+                                 (None, None, None, True, '?include=users'),
+                                 (123, 2, True, True, '?user-id=123&page=2&latest-first=True&include=users'),
                              ))
-    def test_find_direct_award_projects(self, data_client, rmock, user_id, page, latest_first, expected_query_string):
+    def test_find_direct_award_projects(
+        self, data_client, rmock, user_id, page, latest_first, with_users, expected_query_string
+    ):
         rmock.get('/direct-award/projects{}'.format(expected_query_string),
                   json={"project": "ok"},
                   status_code=200)
 
-        result = data_client.find_direct_award_projects(user_id=user_id, page=page, latest_first=latest_first)
+        result = data_client.find_direct_award_projects(
+            user_id=user_id, page=page, latest_first=latest_first, with_users=with_users
+        )
         assert result == {"project": "ok"}
 
     def test_get_direct_award_project(self, data_client, rmock):


### PR DESCRIPTION
For this ticket: https://trello.com/c/eo8gJE4C

### Add `with-users` param to find_direct_award_projects  …
The serialize method for direct award projects has a `with-users`
parameter.

There is a PR up on the api to allow the `list_projects`
endpoint to accept `with-users` as a param

### Make `user-id` optional for direct-award endpoints  …
The endpoints on the API for direct award searches and services take an
optional `user-id` param.

The apiclient forced you to supply one. This made getting all searches
or services for a given project difficult.

### Fix `find_direct_award_project_searches_iter`  …
The `make_iter_method` method expects its second argument to be the name
of the model as returned in a serialized blob. For
direct_award_project_searches this is 'searches' and not 'projects'.

