### PR TITLE
Buyer Email Domain URL should be pluralised

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '10.8.0'
+__version__ = '10.8.1'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -424,7 +424,7 @@ class DataAPIClient(BaseAPIClient):
 
     def create_buyer_email_domain(self, buyer_email_domain, user):
         return self._post_with_updated_by(
-            "/buyer-email-domain",
+            "/buyer-email-domains",
             data={
                 "buyerEmailDomains": {"domainName": buyer_email_domain}
             },

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -488,7 +488,7 @@ class TestBuyerDomainMethods(object):
 
     def test_create_buyer_email_domain(self, data_client, rmock):
         rmock.post(
-            "http://baseurl/buyer-email-domain",
+            "http://baseurl/buyer-email-domains",
             json={"buyerEmailDomains": "result"},
             status_code=201,
         )


### PR DESCRIPTION
For consistency with our other model creation endpoints.

See API changes here: https://github.com/alphagov/digitalmarketplace-api/pull/674/commits/c91f0630462b33fc40b9cbf3b97e2ab1459ad7f4