### PR TITLE
Withdraw brief method

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '11.0.0'
+__version__ = '11.1.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -644,6 +644,13 @@ class DataAPIClient(BaseAPIClient):
             user=user,
         )
 
+    def withdraw_brief(self, brief_id, user):
+        return self._post_with_updated_by(
+            "/briefs/{}/withdraw".format(brief_id),
+            data={},
+            user=user,
+        )
+
     def update_brief_as_unsuccessful(self, brief_id, user):
         return self._post_with_updated_by(
             "/briefs/{}/unsuccessful".format(brief_id),

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -1570,6 +1570,20 @@ class TestBriefMethods(object):
             "updated_by": "user@email.com"
         }
 
+    def test_withdraw_brief(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/briefs/123/withdraw",
+            json={"briefs": "result"},
+            status_code=200,
+        )
+
+        result = data_client.withdraw_brief(123, "user@email.com")
+
+        assert result == {"briefs": "result"}
+        assert rmock.last_request.json() == {
+            "updated_by": "user@email.com"
+        }
+
     def test_update_brief_as_unsuccessful(self, data_client, rmock):
         rmock.post(
             "http://baseurl/briefs/123/unsuccessful",


### PR DESCRIPTION
Required for Trello ticket https://trello.com/c/7kq7pSTr/83-allow-buyers-withdraw-open-opportunities

I guess we've never had to do this via the API client before! It simply follows the pattern for the `cancel_brief` method, which calls the same API endpoint (but with `withdraw` instead of `cancel`).