### PR TITLE
Add closed_on and withdrawn_on parameters to find_briefs method

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '11.1.0'
+__version__ = '11.2.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -664,7 +664,7 @@ class DataAPIClient(BaseAPIClient):
 
     def find_briefs(
         self, user_id=None, status=None, framework=None, lot=None, page=None, human=None, with_users=None,
-        with_clarification_questions=None
+        with_clarification_questions=None, closed_on=None, withdrawn_on=None
     ):
         return self._get(
             "/briefs",
@@ -675,7 +675,9 @@ class DataAPIClient(BaseAPIClient):
                     "page": page,
                     "human": human,
                     "with_users": with_users,
-                    "with_clarification_questions": with_clarification_questions
+                    "with_clarification_questions": with_clarification_questions,
+                    "closed_on": closed_on,
+                    "withdrawn_on": withdrawn_on
                     }
         )
 

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -1653,6 +1653,28 @@ class TestBriefMethods(object):
         assert rmock.called
         assert result == {"briefs": [{"biscuit": "tasty"}]}
 
+    def test_find_briefs_closed_on_date(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/briefs?closed_on=2017-10-20",
+            json={"briefs": [{"applicationsClosedAt": "2017-10-20"}]},
+            status_code=200)
+
+        result = data_client.find_briefs(closed_on="2017-10-20")
+
+        assert rmock.called
+        assert result == {"briefs": [{"applicationsClosedAt": "2017-10-20"}]}
+
+    def test_find_briefs_withdrawn_on_date(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/briefs?withdrawn_on=2017-10-20",
+            json={"briefs": [{"withdrawnAt": "2017-10-20"}]},
+            status_code=200)
+
+        result = data_client.find_briefs(withdrawn_on="2017-10-20")
+
+        assert rmock.called
+        assert result == {"briefs": [{"withdrawnAt": "2017-10-20"}]}
+
     def test_find_briefs_with_clarification_questions(self, data_client, rmock):
         rmock.get(
             "http://baseurl/briefs?with_clarification_questions=True",


### PR DESCRIPTION
Following expansion of callable brief parameters on API