### PR TITLE
Add new update-by-admin audit event type

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '11.3.0'
+__version__ = '11.4.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/audit.py
+++ b/dmapiclient/audit.py
@@ -21,8 +21,9 @@ class AuditTypes(Enum):
     delete_draft_service = "delete_draft_service"
 
     # Live service lifecycle events
-    update_service = "update_service"
     import_service = "import_service"
+    update_service = "update_service"
+    update_service_admin = "update_service_admin"
     update_service_status = "update_service_status"
 
     # Brief lifecycle events

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -547,9 +547,9 @@ class DataAPIClient(BaseAPIClient):
 
     find_services_iter = make_iter_method('find_services', 'services')
 
-    def update_service(self, service_id, service, user):
+    def update_service(self, service_id, service, user, by_admin=False):
         return self._post_with_updated_by(
-            "/services/{}".format(service_id),
+            "/services/{}{}".format(service_id, "?by_admin=True" if by_admin else ""),
             data={
                 "services": service,
             },

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -547,9 +547,9 @@ class DataAPIClient(BaseAPIClient):
 
     find_services_iter = make_iter_method('find_services', 'services')
 
-    def update_service(self, service_id, service, user, by_admin=False):
+    def update_service(self, service_id, service, user, user_role=''):
         return self._post_with_updated_by(
-            "/services/{}{}".format(service_id, "?by_admin=True" if by_admin else ""),
+            "/services/{}{}".format(service_id, "?user-role={}".format(user_role) if user_role else ""),
             data={
                 "services": service,
             },

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
-[pytest]
+[tool:pytest]
 norecursedirs = venv*

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -148,6 +148,19 @@ class TestServiceMethods(object):
         assert result == {"services": "result"}
         assert rmock.called
 
+    def test_update_service_by_admin(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/services/123?by_admin=True",
+            json={"services": "result"},
+            status_code=200,
+        )
+
+        result = data_client.update_service(
+            123, {"foo": "bar"}, "person", by_admin=True)
+
+        assert result == {"services": "result"}
+        assert rmock.called
+
     def test_update_service_status(self, data_client, rmock):
         rmock.post(
             "http://baseurl/services/123/status/published",

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -150,13 +150,13 @@ class TestServiceMethods(object):
 
     def test_update_service_by_admin(self, data_client, rmock):
         rmock.post(
-            "http://baseurl/services/123?by_admin=True",
+            "http://baseurl/services/123?user-role=admin",
             json={"services": "result"},
             status_code=200,
         )
 
         result = data_client.update_service(
-            123, {"foo": "bar"}, "person", by_admin=True)
+            123, {"foo": "bar"}, "person", user_role='admin')
 
         assert result == {"services": "result"}
         assert rmock.called


### PR DESCRIPTION
Part of this ticket: https://trello.com/c/DbYlqSxv/121-exclude-changes-made-by-admin-in-the-approve-edits-section

We need a new audit type to be able to easily distinguish edits by admins from edits by suppliers.

We need the API to take an additional (optional) parameter so it knows which type of audit event to use.