### PR TITLE
New `mapping` parameter for index creation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Records breaking changes from major version bumps
 
+## 12.0.0
+
+PR: [#111](https://github.com/alphagov/digitalmarketplace-apiclient/pull/111)
+
+`mapping` parameter is now required for Search API index creation, as we must be
+able to distinguish between the 'services' mapping and the forthcoming potential
+`briefs` mapping. We might also in future have multiple mappings to cover a new
+non-compatible G-Cloud index, for advance preparation of the new index in advance
+of the framework going live.
+
 ## 11.0.0
 
 PR: [#105](https://github.com/alphagov/digitalmarketplace-apiclient/pull/105)

--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '11.4.0'
+__version__ = '12.0.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/search.py
+++ b/dmapiclient/search.py
@@ -86,10 +86,10 @@ class SearchAPIClient(BaseAPIClient):
     def get_search_url(self, index, q=None, page=None, **filters):
         return self.get_url(path='search', index=index, q=q, page=page, **filters)
 
-    def create_index(self, index):
+    def create_index(self, index, mapping):
         return self._put(
             '/{}'.format(index),
-            data={'type': 'index'}
+            data={'type': 'index', 'mapping': mapping}
         )
 
     def set_alias(self, alias_name, target_index):

--- a/tests/test_search_api_client.py
+++ b/tests/test_search_api_client.py
@@ -108,12 +108,13 @@ class TestSearchApiClient(object):
             json={"status": "ok"},
             status_code=200)
 
-        result = search_client.create_index('new-index')
+        result = search_client.create_index('new-index', 'some-mapping')
 
         assert rmock.called
         assert result['status'] == "ok"
         assert rmock.last_request.json() == {
-            "type": "index"
+            "type": "index",
+            "mapping": "some-mapping",
         }
 
     def test_set_alias(self, search_client, rmock):


### PR DESCRIPTION
Minor - not backward-compatible - change to the search API client, to account for the new `mapping` argument that is shortly arriving in the Search API. See <https://github.com/alphagov/digitalmarketplace-search-api/pull/115>.

https://trello.com/c/5oIKvS1s/100-search-service-for-briefs-plus-indexing-script