### PR TITLE
155 allow admin manager invite new admin users

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '12.0.0'
+__version__ = '12.1.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -428,6 +428,11 @@ class DataAPIClient(BaseAPIClient):
             user=user,
         )
 
+    def email_is_valid_for_admin_user(self, email_address):
+        return self._get(
+            "/users/valid-admin-email", params={'email_address': email_address}
+        )['valid']
+
     # Services
 
     def find_draft_services(self, supplier_id, service_id=None, framework=None):

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -532,6 +532,29 @@ class TestBuyerDomainMethods(object):
         }
 
 
+class TestEmailVaildForAdminMethod(object):
+
+    def test_email_address_with_valid_admin_domain_is_true(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/users/valid-admin-email?email_address=kev%40gov.uk",
+            json={"valid": True},
+            status_code=200
+        )
+        result = data_client.email_is_valid_for_admin_user('kev@gov.uk')
+        assert rmock.called
+        assert result is True
+
+    def test_email_address_with_invalid_admin_domain_is_false(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/users/valid-admin-email?email_address=kev%40not-gov.uk",
+            json={"valid": False},
+            status_code=200
+        )
+        result = data_client.email_is_valid_for_admin_user('kev@not-gov.uk')
+        assert rmock.called
+        assert result is False
+
+
 class TestSupplierMethods(object):
     def test_find_suppliers_with_no_prefix(self, data_client, rmock):
         rmock.get(


### PR DESCRIPTION
https://trello.com/c/2Uc2WMl2/155-allow-super-admin-invite-new-admin-users
https://docs.google.com/document/d/1MjvYx9aQWgcbryiaGrRLOPt_lVm8gIbqOH3vmkKx_fo/edit#

For this new page we agreed to restrict email addresses that can be invited to become an admin by domains listed in the app config.

* New apiclient method using new api end point
* Tests
