### PR TITLE
Add name parameter to 'update_user' method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Records breaking changes from major version bumps
 
+## 13.0.0
+
+PR: [#115](https://github.com/alphagov/digitalmarketplace-apiclient/pull/115)
+
+`name` parameter has been added to `update_user` method,  so any code calling
+this method with positional parameters needs to be updated to use this version.
+
 ## 12.0.0
 
 PR: [#111](https://github.com/alphagov/digitalmarketplace-apiclient/pull/111)

--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '12.2.0'
+__version__ = '13.0.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -373,6 +373,7 @@ class DataAPIClient(BaseAPIClient):
                     active=None,
                     role=None,
                     supplier_id=None,
+                    name=None,
                     updater="no logged-in user"):
         fields = {}
         if locked is not None:
@@ -393,6 +394,11 @@ class DataAPIClient(BaseAPIClient):
         if supplier_id is not None:
             fields.update({
                 'supplierId': supplier_id
+            })
+
+        if name is not None:
+            fields.update({
+                'name': name
             })
 
         params = {

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -485,6 +485,18 @@ class TestUserMethods(object):
             "users": {"active": False}
         }
 
+    def test_can_update_user_name(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/users/123",
+            json={},
+            status_code=200)
+        data_client.update_user(123, name="Star Butterfly", updater="test@example.com")
+        assert rmock.called
+        assert rmock.last_request.json() == {
+            "updated_by": "test@example.com",
+            "users": {"name": "Star Butterfly"}
+        }
+
     def test_can_export_users(self, data_client, rmock):
         rmock.get(
             "http://baseurl/users/export/g-cloud-7",


### PR DESCRIPTION
This was done to enable editing admin user name as per this ticket:
https://trello.com/c/j1jx6KkX/154-allow-super-admin-edit-admin-roles