### PR TITLE
Search and aggregate briefs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ PR: [#116](https://github.com/alphagov/digitalmarketplace-apiclient/pull/116)
 `search_services` method on the search-api-client has been generalized to `search` and now takes a `doc_type` argument.
 This allows more than just services to be searched.
 
-`aggregate_services` method on the search-api-client has been generalized to `aggregate_docs` to allow for aggregating
+`aggregate` method on the search-api-client has been generalized to `aggregate` to allow for aggregating
 briefs too. It takes an extra argument, `doc_type`.
 
 Old:
@@ -20,7 +20,7 @@ search_api_client.search_services(index, q=q, page=page, id_only=id_only, **filt
 
 New:
 ```
-search_api_client.aggregate_docs(index=index, doc_type='services', q=q, aggregations=aggregations)
+search_api_client.aggregate(index=index, doc_type='services', q=q, aggregations=aggregations)
 search_api_client.search(index, doc_type, q=q, page=page, id_only=id_only, **filters)
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,22 @@ Records breaking changes from major version bumps
 
 PR: [#116](https://github.com/alphagov/digitalmarketplace-apiclient/pull/116)
 
+`search_services` method on the search-api-client has been generalized to `search` and now takes a `doc_type` argument.
+This allows more than just services to be searched.
+
 `aggregate_services` method on the search-api-client has been generalized to `aggregate_docs` to allow for aggregating
 briefs too. It takes an extra argument, `doc_type`.
 
 Old:
 ```
 search_api_client.aggregate_services(index=index, q=q, aggregations=aggregations)
+search_api_client.search_services(index, q=q, page=page, id_only=id_only, **filters)
 ```
 
 New:
 ```
 search_api_client.aggregate_docs(index=index, doc_type='services', q=q, aggregations=aggregations)
+search_api_client.search(index, doc_type, q=q, page=page, id_only=id_only, **filters)
 ```
 
 ## 13.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 Records breaking changes from major version bumps
 
+## 14.0.0
+
+PR: [#116](https://github.com/alphagov/digitalmarketplace-apiclient/pull/116)
+
+`aggregate_services` method on the search-api-client has been generalized to `aggregate_docs` to allow for aggregating
+briefs too. It takes an extra argument, `doc_type`.
+
+Old:
+```
+search_api_client.aggregate_services(index=index, q=q, aggregations=aggregations)
+```
+
+New:
+```
+search_api_client.aggregate_docs(index=index, doc_type='services', q=q, aggregations=aggregations)
+```
+
 ## 13.0.0
 
 PR: [#115](https://github.com/alphagov/digitalmarketplace-apiclient/pull/115)

--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '13.1.0'
+__version__ = '14.0.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/base.py
+++ b/dmapiclient/base.py
@@ -33,7 +33,7 @@ def make_iter_method(method_name, *model_names):
         result = backoff_decorator(method)(*args, **kwargs)
         # Filter the list of model names for those that are a key in the response, then take the first.
         # Useful for backwards compatability if response keys might change
-        model_name = next(filter(lambda name: name in result, model_names))
+        model_name = next(model_name for model_name in model_names if model_name in result)
 
         for model in result[model_name]:
             yield model

--- a/dmapiclient/search.py
+++ b/dmapiclient/search.py
@@ -157,7 +157,7 @@ class SearchAPIClient(BaseAPIClient):
             for service in result.get('documents') or result.get('services'):
                 yield service
 
-    def aggregate_docs(self, index, doc_type, q=None, aggregations=[], **filters):
+    def aggregate(self, index, doc_type, q=None, aggregations=[], **filters):
         response = self._get(
             self.get_url(path='aggregations', index=index, doc_type=doc_type, q=q, aggregations=aggregations, **filters)
         )

--- a/dmapiclient/search.py
+++ b/dmapiclient/search.py
@@ -140,6 +140,6 @@ class SearchAPIClient(BaseAPIClient):
 
     search_services_from_url_iter = make_iter_method('search_services_from_url', 'services')
 
-    def aggregate_services(self, index, q=None, aggregations=[], **filters):
-        response = self._get(self.get_url(path='aggregations', index=index, q=q, aggregations=aggregations, **filters))
+    def aggregate_docs(self, index, doc_type, q=None, aggregations=[], **filters):
+        response = self._get(self.get_url(path='aggregations', index=index, doc_type=doc_type, q=q, aggregations=aggregations, **filters))
         return response

--- a/dmapiclient/search.py
+++ b/dmapiclient/search.py
@@ -86,7 +86,7 @@ class SearchAPIClient(BaseAPIClient):
     def get_index_from_search_api_url(self, search_api_url):
         return self._url_reverse(search_api_url)[0]
 
-    def get_search_url(self, index, doc_type='services', q=None, page=None, **filters):
+    def get_search_url(self, index, q=None, page=None, doc_type='services', **filters):
         return self.get_url(path='search', index=index, doc_type=doc_type, q=q, page=page, **filters)
 
     def create_index(self, index, mapping):

--- a/dmapiclient/search.py
+++ b/dmapiclient/search.py
@@ -116,15 +116,9 @@ class SearchAPIClient(BaseAPIClient):
                 raise
         return None
 
-    def search_services(self, index, q=None, page=None, id_only=False, **filters):
+    def search(self, index, doc_type, q=None, page=None, id_only=False, **filters):
         response = self._get(
-            self.get_search_url(index=index, doc_type='services', q=q, page=page, id_only=id_only, **filters)
-        )
-        return response
-
-    def search_briefs(self, index, q=None, page=None, id_only=False, **filters):
-        response = self._get(
-            self.get_search_url(index=index, doc_type='briefs', q=q, page=page, id_only=id_only, **filters)
+            self.get_search_url(index=index, doc_type=doc_type, q=q, page=page, id_only=id_only, **filters)
         )
         return response
 

--- a/dmapiclient/search.py
+++ b/dmapiclient/search.py
@@ -2,7 +2,6 @@
 
 import re
 import six
-import backoff
 try:
     from urllib.parse import urlparse, urlencode, urlunparse, parse_qsl
 except ImportError:
@@ -10,8 +9,8 @@ except ImportError:
     from urllib import urlencode
 
 
-from .base import BaseAPIClient
-from .errors import HTTPError, HTTPTemporaryError
+from .base import BaseAPIClient, make_iter_method
+from .errors import HTTPError
 
 
 class SearchAPIClient(BaseAPIClient):
@@ -137,25 +136,7 @@ class SearchAPIClient(BaseAPIClient):
 
         return self._get(paged_search_api_url)
 
-    # search_services_from_url_iter = make_iter_method('search_services_from_url', 'documents')
-
-    # This is a temporary method to allow for backwards compatability while switching from the search-api returning
-    # `documents` instead of just `services`. The data-api uses this method when locking direct award searches. The api
-    # will need to pull in this apiclient before the search-api changes. Once it does, this method can be removed and
-    # the calle to `make_iter_method` above can be uncommented.
-    def search_services_from_url_iter(self, search_url, id_only):
-        backoff_decorator = backoff.on_exception(backoff.expo, HTTPTemporaryError, max_tries=5)
-        result = backoff_decorator(self.search_services_from_url)(search_url, id_only=id_only)
-        for service in result.get('documents') or result.get('services'):
-            yield service
-
-        while True:
-            if 'next' not in result['links']:
-                return
-
-            result = backoff_decorator(self._get)(result['links']['next'])
-            for service in result.get('documents') or result.get('services'):
-                yield service
+    search_services_from_url_iter = make_iter_method('search_services_from_url', 'documents', 'services')
 
     def aggregate(self, index, doc_type, q=None, aggregations=[], **filters):
         response = self._get(

--- a/dmapiclient/search.py
+++ b/dmapiclient/search.py
@@ -116,11 +116,15 @@ class SearchAPIClient(BaseAPIClient):
         return None
 
     def search_services(self, index, q=None, page=None, id_only=False, **filters):
-        response = self._get(self.get_search_url(index=index, doc_type='services', q=q, page=page, id_only=id_only, **filters))
+        response = self._get(
+            self.get_search_url(index=index, doc_type='services', q=q, page=page, id_only=id_only, **filters)
+        )
         return response
 
     def search_briefs(self, index, q=None, page=None, id_only=False, **filters):
-        response = self._get(self.get_search_url(index=index, doc_type='briefs', q=q, page=page, id_only=id_only, **filters))
+        response = self._get(
+            self.get_search_url(index=index, doc_type='briefs', q=q, page=page, id_only=id_only, **filters)
+        )
         return response
 
     def search_services_from_url(self, search_api_url, id_only=False, page=None):
@@ -141,5 +145,7 @@ class SearchAPIClient(BaseAPIClient):
     search_services_from_url_iter = make_iter_method('search_services_from_url', 'services')
 
     def aggregate_docs(self, index, doc_type, q=None, aggregations=[], **filters):
-        response = self._get(self.get_url(path='aggregations', index=index, doc_type=doc_type, q=q, aggregations=aggregations, **filters))
+        response = self._get(
+            self.get_url(path='aggregations', index=index, doc_type=doc_type, q=q, aggregations=aggregations, **filters)
+        )
         return response

--- a/dmapiclient/search.py
+++ b/dmapiclient/search.py
@@ -116,7 +116,11 @@ class SearchAPIClient(BaseAPIClient):
         return None
 
     def search_services(self, index, q=None, page=None, id_only=False, **filters):
-        response = self._get(self.get_search_url(index=index, q=q, page=page, id_only=id_only, **filters))
+        response = self._get(self.get_search_url(index=index, doc_type='services', q=q, page=page, id_only=id_only, **filters))
+        return response
+
+    def search_briefs(self, index, q=None, page=None, id_only=False, **filters):
+        response = self._get(self.get_search_url(index=index, doc_type='briefs', q=q, page=page, id_only=id_only, **filters))
         return response
 
     def search_services_from_url(self, search_api_url, id_only=False, page=None):

--- a/dmapiclient/search.py
+++ b/dmapiclient/search.py
@@ -19,8 +19,8 @@ class SearchAPIClient(BaseAPIClient):
         self.auth_token = app.config['DM_SEARCH_API_AUTH_TOKEN']
         self.enabled = app.config['ES_ENABLED']
 
-    def _url(self, index, path):
-        return u"/{}/services/{}".format(index, path)
+    def _url(self, index, path, doc_type='services'):
+        return u"/{}/{}/{}".format(index, doc_type, path)
 
     def _url_reverse(self, url):
         url = urlparse(url)
@@ -54,7 +54,7 @@ class SearchAPIClient(BaseAPIClient):
 
         return frontend_params
 
-    def get_url(self, path, index, q, page=None, aggregations=[], id_only=False, **filters):
+    def get_url(self, path, index, q, doc_type='services', page=None, aggregations=[], id_only=False, **filters):
         params = {}
         if q is not None:
             params['q'] = q
@@ -69,7 +69,7 @@ class SearchAPIClient(BaseAPIClient):
 
         self._add_filters_prefix_to_params(params, filters)
 
-        return self._build_url(url=self._url(index=index, path=path), params=params)
+        return self._build_url(url=self._url(index=index, path=path, doc_type=doc_type), params=params)
 
     def get_frontend_params_from_search_api_url(self, search_api_url):
         """
@@ -86,8 +86,8 @@ class SearchAPIClient(BaseAPIClient):
     def get_index_from_search_api_url(self, search_api_url):
         return self._url_reverse(search_api_url)[0]
 
-    def get_search_url(self, index, q=None, page=None, **filters):
-        return self.get_url(path='search', index=index, q=q, page=page, **filters)
+    def get_search_url(self, index, doc_type='services', q=None, page=None, **filters):
+        return self.get_url(path='search', index=index, doc_type=doc_type, q=q, page=page, **filters)
 
     def create_index(self, index, mapping):
         return self._put(

--- a/tests/test_search_api_client.py
+++ b/tests/test_search_api_client.py
@@ -164,34 +164,25 @@ class TestSearchApiClient(object):
                 doc_type='services',
             )
 
-    def test_search_services(self, search_client, rmock):
+    @pytest.mark.parametrize(
+        'index, doc_type',
+        (
+            ('briefs-digital-outcomes-and-speciaists', 'briefs'),
+            ('g-cloud-9', 'services')
+        )
+    )
+    def test_search(self, search_client, rmock, index, doc_type):
         expected_response = {'documents': "myresponse"}
         rmock.get(
-            'http://baseurl/g-cloud/services/search?q=foo&'
-            'filter_minimumContractPeriod=a&'
-            'filter_something=a&filter_something=b',
+            'http://baseurl/{}/{}/search?q=foo&'
+            'filter_something=a&filter_something=b'.format(index, doc_type),
             json=expected_response,
             status_code=200)
-        result = search_client.search_services(
-            index='g-cloud',
+        result = search_client.search(
+            index=index,
+            doc_type=doc_type,
             q='foo',
-            minimumContractPeriod=['a'],
             something=['a', 'b'])
-        assert result == expected_response
-
-    def test_search_briefs(self, search_client, rmock):
-        expected_response = {'documents': "myresponse"}
-        rmock.get(
-            'http://baseurl/briefs-digital-outcomes-and-specialists/briefs/search?q=foo&'
-            'filter_lot=digital-outcomes&'
-            'filter_location=Scotland',
-            json=expected_response,
-            status_code=200)
-        result = search_client.search_briefs(
-            index='briefs-digital-outcomes-and-specialists',
-            q='foo',
-            lot=['digital-outcomes'],
-            location=['Scotland'])
         assert result == expected_response
 
     @pytest.mark.parametrize(
@@ -228,7 +219,7 @@ class TestSearchApiClient(object):
             'http://baseurl/{}/{}/search'.format(index, doc_type),
             json={'documents': "myresponse"},
             status_code=200)
-        result = eval("search_client.search_{}(index='{}')".format(doc_type, index))
+        result = search_client.search(index, doc_type)
         assert result == {'documents': "myresponse"}
         assert rmock.last_request.query == ''
 
@@ -243,7 +234,7 @@ class TestSearchApiClient(object):
             'http://baseurl/{}/{}/search?page=10'.format(index, doc_type),
             json={'documents': "myresponse"},
             status_code=200)
-        result = getattr(search_client, "search_{}".format(doc_type))(index, page=10)
+        result = search_client.search(index, doc_type, page=10)
         assert result == {'documents': "myresponse"}
         assert rmock.last_request.query == 'page=10'
 
@@ -258,7 +249,7 @@ class TestSearchApiClient(object):
             'http://baseurl/{}/{}/search?idOnly=True'.format(index, doc_type),
             json={'documents': "myresponse"},
             status_code=200)
-        result = eval("search_client.search_{}(index='{}', id_only=True)".format(doc_type, index))
+        result = search_client.search(index, doc_type, id_only=True)
         assert result == {'documents': "myresponse"}
 
     @staticmethod

--- a/tests/test_search_api_client.py
+++ b/tests/test_search_api_client.py
@@ -355,7 +355,7 @@ class TestSearchAPIClientIterMethods(object):
         assert results[1]['id'] == 2
         assert results[2]['id'] == 3
 
-    def test_search_services_from_url_iter(self, search_client, rmock):
+    def test_search_services_from_url_iter_with_services_in_response_key(self, search_client, rmock):
         self._test_find_iter(
             search_client, rmock,
             method_name='search_services_from_url_iter',
@@ -363,3 +363,22 @@ class TestSearchAPIClientIterMethods(object):
             url_path='g-cloud/services/search?idOnly=True',
             search_url='http://baseurl/g-cloud/services/search',
             id_only=True)
+
+    def test_search_services_from_url_iter_with_documents_in_response_key(self, search_client, rmock):
+        self._test_find_iter(
+            search_client, rmock,
+            method_name='search_services_from_url_iter',
+            model_name='documents',
+            url_path='g-cloud/services/search?idOnly=True',
+            search_url='http://baseurl/g-cloud/services/search',
+            id_only=True)
+
+    def test_search_services_from_url_iter_with_bad_response_key(self, search_client, rmock):
+        with pytest.raises(AssertionError):
+            self._test_find_iter(
+                search_client, rmock,
+                method_name='search_services_from_url_iter',
+                model_name='i-am-naughty',
+                url_path='g-cloud/services/search?idOnly=True',
+                search_url='http://baseurl/g-cloud/services/search',
+                id_only=True)

--- a/tests/test_search_api_client.py
+++ b/tests/test_search_api_client.py
@@ -356,7 +356,7 @@ class TestSearchAPIClientIterMethods(object):
             },
             status_code=200)
 
-        result = getattr(search_client, method_name)(**kwargs)
+        result = getattr(search_client, method_name)(kwargs['search_url'], kwargs['id_only'])
         results = list(result)
 
         assert len(results) == 3
@@ -369,5 +369,6 @@ class TestSearchAPIClientIterMethods(object):
             search_client, rmock,
             method_name='search_services_from_url_iter',
             model_name='services',
-            url_path='g-cloud/services/search',
-            search_api_url='http://baseurl/g-cloud/services/search')
+            url_path='g-cloud/services/search?idOnly=True',
+            search_url='http://baseurl/g-cloud/services/search',
+            id_only=True)

--- a/tests/test_search_api_client.py
+++ b/tests/test_search_api_client.py
@@ -243,7 +243,7 @@ class TestSearchApiClient(object):
             'http://baseurl/{}/{}/search?page=10'.format(index, doc_type),
             json={'documents': "myresponse"},
             status_code=200)
-        result = eval("search_client.search_{}(index='{}', page=10)".format(doc_type, index))
+        result = getattr(search_client, "search_{}".format(doc_type))(index, page=10)
         assert result == {'documents': "myresponse"}
         assert rmock.last_request.query == 'page=10'
 

--- a/tests/test_search_api_client.py
+++ b/tests/test_search_api_client.py
@@ -191,7 +191,7 @@ class TestSearchApiClient(object):
             ('g-cloud', 'services')
         )
     )
-    def test_aggregate_docs(self, search_client, rmock, index, doc_type):
+    def test_aggregate(self, search_client, rmock, index, doc_type):
         expected_response = {'aggregations': "myresponse"}
         rmock.get(
             'http://baseurl/{}/{}/aggregations?q=foo&aggregations=serviceCategories&'
@@ -199,7 +199,7 @@ class TestSearchApiClient(object):
             'filter_something=a&filter_something=b'.format(index, doc_type),
             json=expected_response,
             status_code=200)
-        result = search_client.aggregate_docs(
+        result = search_client.aggregate(
             index=index,
             doc_type=doc_type,
             q='foo',


### PR DESCRIPTION
Part of this ticket: https://trello.com/c/KcqU7k20

### Set `doc_type` parameter for search functions
We want to be able to search for more than just services. Allowing
doc_type to be passed some functions will allow this. Setting the
default to `services` will maintain some backwards compatibility

### Add `search_briefs` method on search-api-client
This is really similar to `search_services`. The only reason for not
combining them is for backwards compatability. It may be something we
want to do.

### Generalize `aggregate_services` to `aggregate_docs`
We want to aggregate briefs as well as services now. I would have
created a new method `aggregate_briefs` to prevent the breaking change,
but this method is used by helper methods in the frontend and so needs
to be general.
