### PR TITLE
Upgrade Python requests package

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '13.0.0'
+__version__ = '13.1.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         'Flask>=0.10',
         'backoff==1.0.7',
         'monotonic==0.3',
-        'requests==2.7.0',
+        'requests==2.18.4',
         'six==1.9.0'
     ] + ([] if has_enum else ['enum34==1.1.6'])
 )


### PR DESCRIPTION
Upgrades `requests` to address a potential vulnerability: https://snyk.io/vuln/SNYK-PYTHON-REQUESTS-40470

The following repos will need their version of the API client bumped to pull in the update:
- API
- Admin FE
- Briefs FE
- Brief Responses FE
- Buyer FE
- Scripts
- Supplier FE
- User FE

Repos already upgraded:
- Search API
- AWS
- Cloudwatch to Graphite
