### PR TITLE
Allow iter methods to not find `links` key in JSON response

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '14.0.0'
+__version__ = '14.0.1'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/base.py
+++ b/dmapiclient/base.py
@@ -39,7 +39,7 @@ def make_iter_method(method_name, *model_names):
             yield model
 
         while True:
-            if 'next' not in result['links']:
+            if 'next' not in result.get('links', {}):
                 return
 
             result = backoff_decorator(self._get)(result['links']['next'])

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -2125,6 +2125,21 @@ class TestDataAPIClientIterMethods(object):
         assert results[1]['id'] == 2
         assert results[2]['id'] == 3
 
+        # Also check the case that we don't fall over if the API does not give us a `links` dict as part of it's
+        # response
+        rmock.get(
+            'http://baseurl/{}'.format(url_path),
+            json={
+                model_name: [{'id': 1}, {'id': 2}]
+            },
+            status_code=200)
+        result = getattr(data_client, method_name)()
+        results = list(result)
+
+        assert len(results) == 2
+        assert results[0]['id'] == 1
+        assert results[1]['id'] == 2
+
     def test_find_users_iter(self, data_client, rmock):
         self._test_find_iter(
             data_client, rmock,


### PR DESCRIPTION
As part of a PR to standardise the API responses (
alphagov/digitalmarketplace-api#693), we
may no longer be including `links` dicts as part of an endpoints
response.

An endpoint may change from returning a `paginated_result_response`
to returning a `list_result_response` based on the query params
that have been provided.

We discovered that we have iter methods such as the
`find_services_iter` which will break when passing in a supplier
ID paramater as they now return a standardised `list_result_response`
which no longer includes `links`. However the `iter` methods at
the moment rely on getting a `links` key in their result.

Changing our API client to be permissive feels like the easiest
thing to do which won't have any functionality changes, especially
as it is likely that we were only originally returning an empty
list of links from the API so we wouldn't break the API client
rather than providing extra useful information in our responses.