### PR TITLE
Filter brief responses by awarded_at date

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '14.0.1'
+__version__ = '14.1.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -743,14 +743,15 @@ class DataAPIClient(BaseAPIClient):
         return self._get(
             "/brief-responses/{}".format(brief_response_id))
 
-    def find_brief_responses(self, brief_id=None, supplier_id=None, status=None, framework=None):
+    def find_brief_responses(self, brief_id=None, supplier_id=None, status=None, framework=None, awarded_at=None):
         return self._get(
             "/brief-responses",
             params={
                 "brief_id": brief_id,
                 "supplier_id": supplier_id,
                 "status": status,
-                "framework": framework
+                "framework": framework,
+                "awarded_at": awarded_at
             })
 
     find_brief_responses_iter = make_iter_method('find_brief_responses', 'briefResponses')

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -1899,7 +1899,7 @@ class TestBriefResponseMethods(object):
     def test_find_brief_responses(self, data_client, rmock):
         url = (
             "http://baseurl/brief-responses?brief_id=1&supplier_id=2&status=draft&"
-            "framework=digital-outcomes-and-specialists-2"
+            "framework=digital-outcomes-and-specialists-2&awarded_at=2018-01-01"
         )
         rmock.get(
             url,
@@ -1907,7 +1907,8 @@ class TestBriefResponseMethods(object):
             status_code=200)
 
         result = data_client.find_brief_responses(
-            brief_id=1, supplier_id=2, status='draft', framework='digital-outcomes-and-specialists-2'
+            brief_id=1, supplier_id=2, status='draft', framework='digital-outcomes-and-specialists-2',
+            awarded_at="2018-01-01"
         )
 
         assert result == {"briefResponses": []}


### PR DESCRIPTION
`awarded_at` can now be passed into the api as a date in the form of `YYY-MM-DD`.

Merge after:
- [x] https://github.com/alphagov/digitalmarketplace-api/pull/735

https://trello.com/c/LsEbL3jP