### PR TITLE
Filter Briefs by unusccessful_on and cancelled_on dates

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '14.2.0'
+__version__ = '14.3.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -679,7 +679,7 @@ class DataAPIClient(BaseAPIClient):
 
     def find_briefs(
         self, user_id=None, status=None, framework=None, lot=None, page=None, human=None, with_users=None,
-        with_clarification_questions=None, closed_on=None, withdrawn_on=None
+        with_clarification_questions=None, closed_on=None, withdrawn_on=None, cancelled_on=None, unsuccessful_on=None
     ):
         return self._get(
             "/briefs",
@@ -692,7 +692,9 @@ class DataAPIClient(BaseAPIClient):
                     "with_users": with_users,
                     "with_clarification_questions": with_clarification_questions,
                     "closed_on": closed_on,
-                    "withdrawn_on": withdrawn_on
+                    "withdrawn_on": withdrawn_on,
+                    "cancelled_on": cancelled_on,
+                    "unsuccessful_on": unsuccessful_on
                     }
         )
 

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -1740,6 +1740,28 @@ class TestBriefMethods(object):
         assert rmock.called
         assert result == {"briefs": [{"withdrawnAt": "2017-10-20"}]}
 
+    def test_find_briefs_cancelled_on_date(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/briefs?cancelled_on=2017-10-20",
+            json={"briefs": [{"cancelledAt": "2017-10-20"}]},
+            status_code=200)
+
+        result = data_client.find_briefs(cancelled_on="2017-10-20")
+
+        assert rmock.called
+        assert result == {"briefs": [{"cancelledAt": "2017-10-20"}]}
+
+    def test_find_briefs_unsuccessful_on_date(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/briefs?unsuccessful_on=2017-10-20",
+            json={"briefs": [{"unsuccessfulAt": "2017-10-20"}]},
+            status_code=200)
+
+        result = data_client.find_briefs(unsuccessful_on="2017-10-20")
+
+        assert rmock.called
+        assert result == {"briefs": [{"unsuccessfulAt": "2017-10-20"}]}
+
     def test_find_briefs_with_clarification_questions(self, data_client, rmock):
         rmock.get(
             "http://baseurl/briefs?with_clarification_questions=True",


### PR DESCRIPTION
We can already filter Briefs by these date fields on the API route. This PR just adds the kwargs to the API client method. 

Usage:
```
result = data_client.find_briefs(cancelled_on="2017-10-20")
result = data_client.find_briefs(unsuccessful_on="2017-10-20")
```