### PR TITLE
Rename method, fix tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 Records breaking changes from major version bumps
 
+## 15.0.0
+
+PR: [#123](https://github.com/alphagov/digitalmarketplace-apiclient/pull/123)
+
+Removes `get_direct_award_project_services_iter` in favour of `find_direct_award_project_services_iter`, which is the
+more consistent naming scheme.
+
+Old:
+```python
+data_api_client.get_direct_award_project_services_iter(...)
+```
+
+New:
+```python
+data_api_client.find_direct_award_project_services_iter(...)
+```
+
 ## 14.0.0
 
 PR: [#116](https://github.com/alphagov/digitalmarketplace-apiclient/pull/116)

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -900,7 +900,7 @@ class DataAPIClient(BaseAPIClient):
             }
         )
 
-    def get_direct_award_project_services(self, project_id, user_id=None, fields=[]):
+    def find_direct_award_project_services(self, project_id, user_id=None, fields=[]):
         params = {"user-id": user_id}
         if fields:
             params.update({"fields": ','.join(fields)})
@@ -910,10 +910,7 @@ class DataAPIClient(BaseAPIClient):
             params=params
         )
 
-    get_direct_award_project_services_iter = make_iter_method('get_direct_award_project_services', 'services')
-
-    # This is here to maintain compatability with the ModelTrawler class used by the get-model-data script.
-    find_direct_award_project_services_iter = get_direct_award_project_services_iter
+    find_direct_award_project_services_iter = make_iter_method('find_direct_award_project_services', 'services')
 
     def lock_direct_award_project(self, user_email, project_id):
         return self._post_with_updated_by(


### PR DESCRIPTION
Remove get_direct_award_project_services_iter in favour of find_x equivalent; fix some tests to use _test_find_iter correctly

## Ticket
https://trello.com/c/QV36xkLW/216-getmodeliter-v-findmodeliter-in-the-apiclient