### PR TITLE
Add fixture for supplier data from api

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '14.3.0'
+__version__ = '14.4.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/api_stubs.py
+++ b/dmapiclient/api_stubs.py
@@ -66,3 +66,56 @@ def brief(status="draft",
         brief['briefs']['clarificationQuestionsAreClosed'] = clarification_questions_closed
 
     return brief
+
+
+def supplier(id=1234, contact_id=4321, other_company_registration_number=0):
+    data = {
+        "suppliers": {
+            "companiesHouseNumber": "12345678",
+            "contactInformation": [
+                {
+                    "address1": "123 Fake Road",
+                    "city": "Madeupolis",
+                    "contactName": "Mr E Man",
+                    "email": "mre@company.com",
+                    "id": contact_id,
+                    "links": {
+                        "self": "http://localhost:5000/suppliers/{id}/contact-information/{contact_id}".format(
+                            id=id, contact_id=contact_id
+                        )
+                    },
+                    "phoneNumber": "01234123123",
+                    "postcode": "A11 1AA",
+                    "website": "https://www.mre.company"
+                }
+            ],
+            "description": "I'm a supplier.",
+            "dunsNumber": "123456789",
+            "id": id,
+            "links": {
+                "self": "http://localhost:5000/suppliers/{id}".format(id=id)
+            },
+            "name": "My Little Company",
+            "organisationSize": "micro",
+            "registeredName": "My Little Registered Company",
+            "registrationCountry": "country:GB",
+            "registrationDate": "2000-01-01",
+            "service_counts": {
+                "G-Cloud 9": 109,
+                "G-Cloud 8": 108,
+                "G-Cloud 7": 107,
+                "G-Cloud 6": 106,
+                "G-Cloud 5": 105,
+            },
+            "tradingStatus": "limited company",
+            "vatNumber": "111222333"
+        }
+    }
+
+    if other_company_registration_number:
+        data['suppliers']['otherCompanyRegistrationNumber'] = other_company_registration_number
+        data['suppliers']['registrationCountry'] = 'country:NZ'
+        del data['suppliers']['companiesHouseNumber']
+        del data['suppliers']['vatNumber']
+
+    return data

--- a/tests/test_api_stubs.py
+++ b/tests/test_api_stubs.py
@@ -162,3 +162,160 @@ def test_brief():
             "clarificationQuestions": [],
         }
     }
+
+
+def test_supplier():
+    assert api_stubs.supplier() == {
+        'suppliers': {
+            'companiesHouseNumber': '12345678',
+            'contactInformation': [{
+                'address1': '123 Fake Road',
+                'city': 'Madeupolis',
+                'contactName': 'Mr E Man',
+                'email': 'mre@company.com',
+                'id': 4321,
+                'links': {
+                    'self': 'http://localhost:5000/suppliers/1234/contact-information/4321'
+                },
+                'phoneNumber': '01234123123',
+                'postcode': 'A11 1AA',
+                "website": "https://www.mre.company"
+            }],
+            'description': "I'm a supplier.",
+            'dunsNumber': '123456789',
+            'id': 1234,
+            'links': {
+                'self': 'http://localhost:5000/suppliers/1234'
+            },
+            'name': 'My Little Company',
+            'organisationSize': 'micro',
+            'registeredName': 'My Little Registered Company',
+            'registrationCountry': 'country:GB',
+            'registrationDate': '2000-01-01',
+            'service_counts': {
+                "G-Cloud 9": 109,
+                "G-Cloud 8": 108,
+                "G-Cloud 7": 107,
+                "G-Cloud 6": 106,
+                "G-Cloud 5": 105,
+            },
+            'tradingStatus': 'limited company',
+            'vatNumber': '111222333'
+        }
+    }
+
+    assert api_stubs.supplier(id=9999) == {
+        'suppliers': {
+            'companiesHouseNumber': '12345678',
+            'contactInformation': [{
+                'address1': '123 Fake Road',
+                'city': 'Madeupolis',
+                'contactName': 'Mr E Man',
+                'email': 'mre@company.com',
+                'id': 4321,
+                'links': {
+                    'self': 'http://localhost:5000/suppliers/9999/contact-information/4321'
+                },
+                'phoneNumber': '01234123123',
+                'postcode': 'A11 1AA',
+                "website": "https://www.mre.company"
+            }],
+            'description': "I'm a supplier.",
+            'dunsNumber': '123456789',
+            'id': 9999,
+            'links': {
+                'self': 'http://localhost:5000/suppliers/9999'
+            },
+            'name': 'My Little Company',
+            'organisationSize': 'micro',
+            'registeredName': 'My Little Registered Company',
+            'registrationCountry': 'country:GB',
+            'registrationDate': '2000-01-01',
+            'service_counts': {
+                "G-Cloud 9": 109,
+                "G-Cloud 8": 108,
+                "G-Cloud 7": 107,
+                "G-Cloud 6": 106,
+                "G-Cloud 5": 105,
+            },
+            'tradingStatus': 'limited company',
+            'vatNumber': '111222333'
+        }
+    }
+
+    assert api_stubs.supplier(contact_id=9999) == {
+        'suppliers': {
+            'companiesHouseNumber': '12345678',
+            'contactInformation': [{
+                'address1': '123 Fake Road',
+                'city': 'Madeupolis',
+                'contactName': 'Mr E Man',
+                'email': 'mre@company.com',
+                'id': 9999,
+                'links': {
+                    'self': 'http://localhost:5000/suppliers/1234/contact-information/9999'
+                },
+                'phoneNumber': '01234123123',
+                'postcode': 'A11 1AA',
+                "website": "https://www.mre.company"
+            }],
+            'description': "I'm a supplier.",
+            'dunsNumber': '123456789',
+            'id': 1234,
+            'links': {
+                'self': 'http://localhost:5000/suppliers/1234'
+            },
+            'name': 'My Little Company',
+            'organisationSize': 'micro',
+            'registeredName': 'My Little Registered Company',
+            'registrationCountry': 'country:GB',
+            'registrationDate': '2000-01-01',
+            'service_counts': {
+                "G-Cloud 9": 109,
+                "G-Cloud 8": 108,
+                "G-Cloud 7": 107,
+                "G-Cloud 6": 106,
+                "G-Cloud 5": 105,
+            },
+            'tradingStatus': 'limited company',
+            'vatNumber': '111222333'
+        }
+    }
+
+    assert api_stubs.supplier(other_company_registration_number=123456) == {
+        'suppliers': {
+            'contactInformation': [{
+                'address1': '123 Fake Road',
+                'city': 'Madeupolis',
+                'contactName': 'Mr E Man',
+                'email': 'mre@company.com',
+                'id': 4321,
+                'links': {
+                    'self': 'http://localhost:5000/suppliers/1234/contact-information/4321'
+                },
+                'phoneNumber': '01234123123',
+                'postcode': 'A11 1AA',
+                "website": "https://www.mre.company"
+            }],
+            'description': "I'm a supplier.",
+            'dunsNumber': '123456789',
+            'id': 1234,
+            'links': {
+                'self': 'http://localhost:5000/suppliers/1234'
+            },
+            'name': 'My Little Company',
+            'otherCompanyRegistrationNumber': 123456,
+            'organisationSize': 'micro',
+            'registeredName': 'My Little Registered Company',
+            'registrationCountry': 'country:NZ',
+            'registrationDate': '2000-01-01',
+            'service_counts': {
+                "G-Cloud 9": 109,
+                "G-Cloud 8": 108,
+                "G-Cloud 7": 107,
+                "G-Cloud 6": 106,
+                "G-Cloud 5": 105,
+            },
+            'tradingStatus': 'limited company',
+        }
+    }


### PR DESCRIPTION
## Summary
Add a fixture for supplier data from the API to help test the additions to the framework application tasklist.

## Ticket
https://trello.com/c/8Ahl8YNc/43-supplier-account-add-supplier-details-to-tasklist-page