### PR TITLE
Remove registration date

### DIFF
--- a/dmapiclient/api_stubs.py
+++ b/dmapiclient/api_stubs.py
@@ -99,7 +99,6 @@ def supplier(id=1234, contact_id=4321, other_company_registration_number=0):
             "organisationSize": "micro",
             "registeredName": "My Little Registered Company",
             "registrationCountry": "country:GB",
-            "registrationDate": "2000-01-01",
             "service_counts": {
                 "G-Cloud 9": 109,
                 "G-Cloud 8": 108,

--- a/tests/test_api_stubs.py
+++ b/tests/test_api_stubs.py
@@ -191,7 +191,6 @@ def test_supplier():
             'organisationSize': 'micro',
             'registeredName': 'My Little Registered Company',
             'registrationCountry': 'country:GB',
-            'registrationDate': '2000-01-01',
             'service_counts': {
                 "G-Cloud 9": 109,
                 "G-Cloud 8": 108,
@@ -230,7 +229,6 @@ def test_supplier():
             'organisationSize': 'micro',
             'registeredName': 'My Little Registered Company',
             'registrationCountry': 'country:GB',
-            'registrationDate': '2000-01-01',
             'service_counts': {
                 "G-Cloud 9": 109,
                 "G-Cloud 8": 108,
@@ -269,7 +267,6 @@ def test_supplier():
             'organisationSize': 'micro',
             'registeredName': 'My Little Registered Company',
             'registrationCountry': 'country:GB',
-            'registrationDate': '2000-01-01',
             'service_counts': {
                 "G-Cloud 9": 109,
                 "G-Cloud 8": 108,
@@ -308,7 +305,6 @@ def test_supplier():
             'organisationSize': 'micro',
             'registeredName': 'My Little Registered Company',
             'registrationCountry': 'country:NZ',
-            'registrationDate': '2000-01-01',
             'service_counts': {
                 "G-Cloud 9": 109,
                 "G-Cloud 8": 108,


### PR DESCRIPTION
## Summary
Registration date is a field we are no longer interested in, so we should remove all references from it as we will be dropping it from the API shortly.

## Ticket
https://trello.com/c/M2jPJ3kZ/58-purge-registration-date-from-logic-and-data