### PR TITLE
request id handling: switch to using request.get_onwards_request_headers if available

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '14.5.0'
+__version__ = '14.6.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -14,27 +14,43 @@ def data_client():
 
 
 class TestDataApiClient(object):
-    def test_request_id_is_added_if_available(self, data_client, rmock, app):
+    def test_onwards_request_headers_added_if_available(self, data_client, rmock, app):
+        rmock.get("http://baseurl/_status", json={"status": "ok"}, status_code=200)
         with app.test_request_context('/'):
-            app.config['DM_REQUEST_ID_HEADER'] = 'DM-Request-Id'
-            request.request_id = 'generated'
-            rmock.get("http://baseurl/_status", json={"status": "ok"}, status_code=200)
+            # add a simple mock callable instead of using a full request implementation
+            request.get_onwards_request_headers = mock.Mock()
+            request.get_onwards_request_headers.return_value = {
+                "Douce": "bronze",
+                "Kennedy": "gold",
+            }
 
             data_client.get_status()
 
-            assert rmock.last_request.headers["DM-Request-Id"] == "generated"
+            assert rmock.last_request.headers["Douce"] == "bronze"
+            assert rmock.last_request.headers["kennedy"] == "gold"
 
-    def test_request_id_is_not_added_if_logging_is_not_loaded(self, data_client, rmock, app):
-        headers = {'DM-Request-Id': 'generated'}
-        with app.test_request_context('/', headers=headers):
-            rmock.get(
-                "http://baseurl/_status",
-                json={"status": "ok"},
-                status_code=200)
+            assert request.get_onwards_request_headers.call_args_list == [
+                # just a single, arg-less call
+                (),
+            ]
+
+    def test_onwards_request_headers_not_available(self, data_client, rmock, app):
+        rmock.get("http://baseurl/_status", json={"status": "ok"}, status_code=200)
+        with app.test_request_context('/'):
+            # really just asserting no exception arose from performing a call without get_onwards_request_headers being
+            # available
+            data_client.get_status()
+
+    def test_request_id_fallback(self, data_client, rmock, app):
+        # request.request_id is an old interface which we're still supporting here just for compatibility
+        rmock.get("http://baseurl/_status", json={"status": "ok"}, status_code=200)
+        app.config["DM_REQUEST_ID_HEADER"] = "Bar"
+        with app.test_request_context('/'):
+            request.request_id = "Ormond"
 
             data_client.get_status()
 
-            assert "DM-Request-Id" not in rmock.last_request.headers
+            assert rmock.last_request.headers["bar"] == "Ormond"
 
     def test_init_app_sets_attributes(self, data_client):
         app = mock.Mock()


### PR DESCRIPTION
...however still fall back to using `request.request_id` failing that for compatibility: I *think* I've upgraded the `-utils` on all the relevant apps but could have missed something, so playing safe.

Strikes me that there isn't really any sort of integration test for this functionality - checking that a header makes it all the way through. Not sure where such a thing would live.

Trello https://trello.com/c/exuNFb7A/357-zipkin-headers-pt2-api-client , part of the broader https://trello.com/c/UOXf4vZZ/308-make-use-of-zipkin-headers-in-preference-to-request-id

