### PR TITLE
Bump version to 15.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 Records breaking changes from major version bumps
 
-## 15.0.0
+## (14.5.0 ->) 15.0.0
+
+:rotating_light: **Note:** there was mistaken versioning between `14.5.0` and `15.0.0`, meaning that the changes
+described below for `15.0.0` actually applied from `14.5.0` onwards.
 
 PR: [#123](https://github.com/alphagov/digitalmarketplace-apiclient/pull/123)
 

--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '14.7.0'
+__version__ = '15.0.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa


### PR DESCRIPTION
PR #123 failed to *actually* bump the version to `15.0.0` meaning the potentially breaking change got introduced as of `14.5.0`, so here we're just quickly bumping it before that causes a problem.