### PR TITLE
Update API stubs to not delete VAT number

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '15.0.0'
+__version__ = '15.0.1'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/api_stubs.py
+++ b/dmapiclient/api_stubs.py
@@ -113,8 +113,9 @@ def supplier(id=1234, contact_id=4321, other_company_registration_number=0):
 
     if other_company_registration_number:
         data['suppliers']['otherCompanyRegistrationNumber'] = other_company_registration_number
-        data['suppliers']['registrationCountry'] = 'country:NZ'
+        # We allow one or other of these registration numbers, but not both
         del data['suppliers']['companiesHouseNumber']
-        del data['suppliers']['vatNumber']
+        # Companies without a Companies House number aren't necessarily overseas, but they might well be
+        data['suppliers']['registrationCountry'] = 'country:NZ'
 
     return data

--- a/tests/test_api_stubs.py
+++ b/tests/test_api_stubs.py
@@ -313,5 +313,6 @@ def test_supplier():
                 "G-Cloud 5": 105,
             },
             'tradingStatus': 'limited company',
+            'vatNumber': '111222333'
         }
     }


### PR DESCRIPTION
We require everyone to answer the "VAT number" question, even if just to say "No I'm not VAT registered".  So we shouldn't delete it from the fake API response here.