### PR TITLE
Add method for copying all lots services

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '15.0.1'
+__version__ = '15.1.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -473,10 +473,17 @@ class DataAPIClient(BaseAPIClient):
             user=user,
         )
 
-    def copy_draft_service_from_existing_service(self, service_id, user):
+    def copy_draft_service_from_existing_service(self, service_id, user, data={}):
         return self._put_with_updated_by(
             "/draft-services/copy-from/{}".format(service_id),
-            data={},
+            data=data,
+            user=user,
+        )
+
+    def copy_published_from_framework(self, framework_slug, lot_slug, user, data={}):
+        return self._post_with_updated_by(
+            "/draft-services/{}/{}/copy-published-from-framework".format(framework_slug, lot_slug),
+            data=data,
             user=user,
         )
 

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -1116,13 +1116,33 @@ class TestDraftServiceMethods(object):
         )
 
         result = data_client.copy_draft_service_from_existing_service(
-            2, 'user'
+            2, 'user', {'some': 'data'}
         )
 
         assert result == {"done": "it"}
         assert rmock.called
         assert rmock.request_history[0].json() == {
-            'updated_by': 'user'
+            'updated_by': 'user',
+            'some': 'data',
+        }
+
+    def test_copy_published_from_framework(
+            self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/draft-services/dos-cloud/sausages/copy-published-from-framework",
+            json={"done": "it"},
+            status_code=201,
+        )
+
+        result = data_client.copy_published_from_framework(
+            'dos-cloud', 'sausages', 'user', {'some': 'data'}
+        )
+
+        assert result == {"done": "it"}
+        assert rmock.called
+        assert rmock.request_history[0].json() == {
+            'updated_by': 'user',
+            'some': 'data',
         }
 
     def test_copy_draft_service(self, data_client, rmock):


### PR DESCRIPTION
Part of this trello ticket: https://trello.com/c/Nbv7N4lf

### Add method for copying all lots services
This is for calling the endpoint on the api for copying all of a
particular lots services between frameworks.

### Switch from flake8-putty to flake8-per-file-ignores
To support newer Python3 syntax through flake8 3.5.0. No per file
ignores are required currently but installing it keeps consistency with
how we use it elsewhere.