### PR TITLE
Update framework via data client

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '15.2.0'
+__version__ = '15.3.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -606,6 +606,13 @@ class DataAPIClient(BaseAPIClient):
     def get_framework(self, slug):
         return self._get("/frameworks/{}".format(slug))
 
+    def update_framework(self, framework_slug, data, user):
+        return self._post_with_updated_by(
+            "/frameworks/{}".format(framework_slug),
+            data={"frameworks": data},
+            user=user
+        )
+
     def get_interested_suppliers(self, framework_slug):
         return self._get(
             "/frameworks/{}/interest".format(framework_slug)

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -1563,6 +1563,23 @@ class TestFrameworkMethods(object):
         assert result == {'frameworks': {'g-cloud-11': 'yes'}}
         assert rmock.called
 
+    def test_update_framework(self, data_client, rmock):
+        rmock.post(
+            'http://baseurl/frameworks/g-cloud-11',
+            json={'frameworks': {'key': 'value'}},
+            status_code=200)
+
+        result = data_client.update_framework(framework_slug='g-cloud-11', data={'key': 'value'}, user='me@my.mine')
+
+        assert result == {'frameworks': {'key': 'value'}}
+        assert rmock.called
+        assert rmock.request_history[0].json() == {
+            "frameworks": {
+                'key': 'value'
+            },
+            "updated_by": "me@my.mine"
+        }
+
 
 class TestBriefMethods(object):
     def test_create_brief(self, data_client, rmock):


### PR DESCRIPTION
 ## Summary
Adds method for updating a framework via the apiclient. Going to be used
to update all existing frameworks with their lifecycle dates.
Bumps version to 15.3.0.

 ## Ticket
https://trello.com/c/BVPgZRZc/65-store-datetimes-relating-to-the-framework-lifecycle-on-the-api