### PR TITLE
Pin to Flask==0.10.1

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '15.3.0'
+__version__ = '15.3.1'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'Flask>=0.10',
+        'Flask==0.10.1',
         'backoff==1.0.7',
         'monotonic==0.3',
         'requests==2.18.4',


### PR DESCRIPTION
 ## Summary
Our frontend apps all depend on Flask v0.10.1 specifically, but this
repository doesn't. Flask released v1.0.0 over the weekend and this is
trying to pull it in now, which breaks things. Let's pin this dependency
to the specific version and review if/how/when/whether we should upgrade
to Flask v1.0.0