### PR TITLE
New DataAPIClient method for supplier export route

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '16.2.0'
+__version__ = '16.3.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -292,6 +292,11 @@ class DataAPIClient(BaseAPIClient):
     find_framework_suppliers_iter = make_iter_method('find_framework_suppliers', 'supplierFrameworks')
     find_framework_suppliers_iter.__name__ = str("find_framework_suppliers_iter")
 
+    def export_suppliers(self, framework_slug):
+        return self._get(
+            "/suppliers/export/{}".format(framework_slug)
+        )
+
     # Users
 
     def create_user(self, user):

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -1016,6 +1016,15 @@ class TestSupplierMethods(object):
         assert result == {'supplierFrameworks': [{"agreementReturned": False}, {"agreementReturned": True}]}
         assert rmock.called
 
+    def test_can_export_suppliers(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/suppliers/export/g-cloud-9",
+            json={"suppliers": "result"},
+            status_code=200)
+        result = data_client.export_suppliers('g-cloud-9')
+        assert rmock.called
+        assert result == {"suppliers": "result"}
+
 
 class TestAgreementMethods(object):
     def test_put_signed_agreement_on_hold(self, data_client, rmock):


### PR DESCRIPTION
Trello: https://trello.com/c/gVkJo8Zj/70-update-framework-manager-user-download-list-to-include-additional-fields

Adds a new method to call the new Supplier export route on the API (see branch in progress: https://github.com/alphagov/digitalmarketplace-api/compare/178-update-framework-manager-user-download-list-to-include-additional-fields-ver-2). 

