### PR TITLE
208 delete users code that takes the user and strips all the personal data out

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '16.3.0'
+__version__ = '16.4.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -141,6 +141,13 @@ class DataAPIClient(BaseAPIClient):
             user=user,
         )
 
+    def remove_contact_information_personal_data(self, supplier_id, contact_id, user):
+        return self._post_with_updated_by(
+            "/suppliers/{}/contact-information/{}/remove-personal-data".format(supplier_id, contact_id),
+            data={},
+            user=user,
+        )
+
     def get_framework_interest(self, supplier_id):
         return self._get(
             "/suppliers/{}/frameworks/interest".format(supplier_id)
@@ -429,6 +436,9 @@ class DataAPIClient(BaseAPIClient):
         logger.info("Updated user {user_id} fields {params}",
                     extra={"user_id": user_id, "params": params})
         return user
+
+    def remove_user_personal_data(self, user_id, user):
+        return self._post_with_updated_by("/users/{}/remove-personal-data".format(user_id), data={}, user=user)
 
     def export_users(self, framework_slug):
         return self._get(

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -313,7 +313,7 @@ class DataAPIClient(BaseAPIClient):
                 "users": user,
             })
 
-    def find_users(self, supplier_id=None, page=None, role=None):
+    def find_users(self, supplier_id=None, page=None, role=None, personal_data_deleted=None):
         params = {}
         if supplier_id is not None and role is not None:
             raise ValueError(
@@ -324,6 +324,8 @@ class DataAPIClient(BaseAPIClient):
             params['role'] = role
         if page is not None:
             params['page'] = page
+        if personal_data_deleted is not None:
+            params['personal_data_deleted'] = personal_data_deleted
         return self._get("/users", params=params)
 
     find_users_iter = make_iter_method('find_users', 'users')

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -220,10 +220,11 @@ class TestUserMethods(object):
             'created_at': "2015-05-05T05:05:05",
             'updated_at': "2015-05-05T05:05:05",
             'password_changed_at': "2015-05-05T05:05:05",
+            'personal_data_deleted': False,
             'supplier': {
                 'supplier_id': 1234,
                 'name': 'name'
-            }
+            },
         }}
 
     def test_find_users_by_supplier_id(self, data_client, rmock):
@@ -257,6 +258,28 @@ class TestUserMethods(object):
         user = data_client.find_users(page=12)
 
         assert user == self.user()
+
+    def test_find_users_by_personal_data_deleted_false(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/users?personal_data_deleted=false",
+            json=self.user(),
+            status_code=200)
+        user = data_client.find_users(personal_data_deleted=False)
+
+        assert user == self.user()
+
+    def test_find_users_by_personal_data_deleted_true(self, data_client, rmock):
+        user = self.user()
+        user['users'].update({'personal_data_deleted': True})
+        expected_data = user.copy()
+
+        rmock.get(
+            "http://baseurl/users?personal_data_deleted=true",
+            json=user,
+            status_code=200)
+        user = data_client.find_users(personal_data_deleted=True)
+
+        assert user == expected_data
 
     def test_get_user_by_id(self, data_client, rmock):
         rmock.get(

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -513,6 +513,16 @@ class TestUserMethods(object):
             "users": {"name": "Star Butterfly"}
         }
 
+    def test_can_remove_user_personal_data(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/users/123/remove-personal-data",
+            json={},
+            status_code=200
+        )
+        data_client.remove_user_personal_data(123, "test@example.com")
+        assert rmock.called
+        assert rmock.last_request.json() == {"updated_by": "test@example.com"}
+
     def test_can_export_users(self, data_client, rmock):
         rmock.get(
             "http://baseurl/users/export/g-cloud-7",
@@ -726,6 +736,16 @@ class TestSupplierMethods(object):
         assert rmock.request_history[0].json() == {
             'contactInformation': {'foo': 'bar'}, 'updated_by': 'supplier'
         }
+
+    def test_remove_contact_information_personal_data(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/suppliers/123/contact-information/1/remove-personal-data",
+            json={},
+            status_code=200
+        )
+        data_client.remove_contact_information_personal_data(123, 1, "test@example.com")
+        assert rmock.called
+        assert rmock.last_request.json() == {"updated_by": "test@example.com"}
 
     def test_get_framework_interest(self, data_client, rmock):
         rmock.get(


### PR DESCRIPTION
https://github.com/alphagov/digitalmarketplace-api/pull/802

This PR:
* Bumps the version
* Adds a new AuditType for removing the personal data from a user
* Adds methods to interact with the `remove-personal-data` user and contact information api endpoints
* Adds tests for these methods