### PR TITLE
Set application company details

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '17.1.0'
+__version__ = '17.2.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -217,6 +217,22 @@ class DataAPIClient(BaseAPIClient):
             user=user,
         )
 
+    def set_supplier_framework_application_company_details_confirmed(
+        self,
+        supplier_id,
+        framework_slug,
+        application_company_details_confirmed,
+        user,
+    ):
+        return self._post_with_updated_by(
+            "/suppliers/{}/frameworks/{}".format(
+                supplier_id, framework_slug),
+            data={
+                "frameworkInterest": {"applicationCompanyDetailsConfirmed": application_company_details_confirmed},
+            },
+            user=user,
+        )
+
     def register_framework_agreement_returned(self, supplier_id, framework_slug, user, uploader_user_id=None):
         framework_interest_dict = {
             "agreementReturned": True,

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -846,6 +846,21 @@ class TestSupplierMethods(object):
             "updated_by": 'user'
         }
 
+    def test_set_supplier_framework_application_company_details_confirmed(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/suppliers/8765/frameworks/g-cloud-10",
+            json={"frameworkInterest": {"applicationCompanyDetailsConfirmed": True}},
+            status_code=200)
+
+        result = data_client.set_supplier_framework_application_company_details_confirmed(8765, 'g-cloud-10', True,
+                                                                                          'user')
+        assert result == {"frameworkInterest": {"applicationCompanyDetailsConfirmed": True}}
+        assert rmock.called
+        assert rmock.request_history[0].json() == {
+            "frameworkInterest": {"applicationCompanyDetailsConfirmed": True},
+            "updated_by": 'user'
+        }
+
     def test_register_framework_agreement_returned_with_uploader_user_id(self, data_client, rmock):
         rmock.post(
             "http://baseurl/suppliers/123/frameworks/g-cloud-8",


### PR DESCRIPTION
 ## Summary
Suppliers need to confirm that their company details are correct when
they're applying to a framework, so we need an API setter for this.

 ## Ticket
https://trello.com/c/V0FSdOCJ/188