### PR TITLE
Bump flake8 to version 3.5.0

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,5 +7,3 @@ exclude = venv*,__pycache__,node_modules,bower_components
 ignore = D203,W503
 max-complexity = 11
 max-line-length = 120
-per-file-ignores =
-    **/__init__.py : F401

--- a/.flake8
+++ b/.flake8
@@ -7,5 +7,5 @@ exclude = venv*,__pycache__,node_modules,bower_components
 ignore = D203,W503
 max-complexity = 11
 max-line-length = 120
-putty-ignore =
-    **/__init__.py : +F401
+per-file-ignores =
+    **/__init__.py : F401

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 coverage==3.7.1
-flake8==2.6.2
-flake8-putty==0.4.0
+flake8==3.5.0
+flake8-per-file-ignores==0.4.0
 mock==2.0.0
 pytest==3.2.3
 pytest-cov==2.5.1


### PR DESCRIPTION
Also replaces `flake8-putty` with `flake8-per-file-ignores`.

You might need to delete and rebuild your venv when this change hits.