### PR TITLE
Add 'we are still assessing' method

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '17.2.0'
+__version__ = '17.3.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '17.3.0'
+__version__ = '17.4.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/base.py
+++ b/dmapiclient/base.py
@@ -55,6 +55,13 @@ class BaseAPIClient(object):
         self.auth_token = auth_token
         self.enabled = enabled
 
+    def _patch(self, url, data):
+        return self._request("PATCH", url, data=data)
+
+    def _patch_with_updated_by(self, url, data, user):
+        data = dict(data, updated_by=user)
+        return self._patch(url, data)
+
     def _put(self, url, data):
         return self._request("PUT", url, data=data)
 

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -1023,6 +1023,13 @@ class DataAPIClient(BaseAPIClient):
             user=user_email,
         )
 
+    def mark_direct_award_project_as_still_assessing(self, project_id, user_email):
+        return self._patch_with_updated_by(
+            f"/direct-award/projects/{project_id}",
+            data={"project": {"stillAssessing": True}},
+            user=user_email,
+        )
+
     # Outcomes
 
     def update_outcome(self, outcome_id, outcome_data, user_email):

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -2285,6 +2285,26 @@ class TestDirectAwardMethods(object):
             "updated_by": "user@email.com"
         }
 
+    def test_mark_direct_award_project_as_still_assessing(self, data_client, rmock):
+        rmock.patch(
+            '/direct-award/projects/31415',
+            json={'project': 'ok'},
+            status_code=200,
+        )
+
+        result = data_client.mark_direct_award_project_as_still_assessing(
+            user_email="user@email.com",
+            project_id=31415,
+        )
+
+        assert result == {"project": "ok"}
+        assert rmock.last_request.json() == {
+            "project": {
+                "stillAssessing": True,
+            },
+            "updated_by": "user@email.com"
+        }
+
 
 class TestOutcomeMethods(object):
     def test_update_outcome(self, data_client, rmock):


### PR DESCRIPTION
This PR adds the apiclient method needed for the 'we are still assessing flow' [ticket].

It also adds a `_patch` method to the base api client class, so that the new PATCH endpoint from https://github.com/alphagov/digitalmarketplace-api/pull/807 can be used.

[ticket]: https://trello.com/c/5Lrp1lOK/110-fe-8-we-are-still-assessing-flow