### PR TITLE
Add generic update method

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '18.0.0'
+__version__ = '18.1.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -1030,6 +1030,13 @@ class DataAPIClient(BaseAPIClient):
             user=user_email,
         )
 
+    def update_direct_award_project(self, project_id, project_data, user_email):
+        return self._patch_with_updated_by(
+            f"/direct-award/projects/{project_id}",
+            data={"project": project_data},
+            user=user_email,
+        )
+
     # Outcomes
 
     def update_outcome(self, outcome_id, outcome_data, user_email):

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -2305,6 +2305,29 @@ class TestDirectAwardMethods(object):
             "updated_by": "user@email.com"
         }
 
+    def test_update_direct_award_project(self, data_client, rmock):
+        rmock.patch(
+            '/direct-award/projects/31415',
+            json={'project': 'ok'},
+            status_code=200,
+        )
+
+        result = data_client.update_direct_award_project(
+            user_email="user@email.com",
+            project_id=31415,
+            project_data={
+                'foo': 'baa',
+            }
+        )
+
+        assert result == {"project": "ok"}
+        assert rmock.last_request.json() == {
+            "project": {
+                "foo": 'baa',
+            },
+            "updated_by": "user@email.com"
+        }
+
 
 class TestOutcomeMethods(object):
     def test_update_outcome(self, data_client, rmock):


### PR DESCRIPTION
Add generic update method: the API's method is intended to be generic, so logically (arguably) the API Client should be fairly generic too.

Goes with https://github.com/alphagov/digitalmarketplace-api/pull/814

https://trello.com/c/7wlBbGU0/138-add-step-3-assessing-your-service-and-badges