### PR TITLE
Log more detail on request exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Records breaking changes from major version bumps
 
+## 18.0.0
+
+PR: [#151](https://github.com/alphagov/digitalmarketplace-apiclient/pull/151)
+
+The default request error message for unrecognised/unhandled errors has changed from 'Request failed' to 'Unknown request failure in dmapiclient'. 'Request failed' should be seen only in exceptional circumstances - most exceptions raised from failed requests should now hold the str() and repr() calls of the request error as their message.
+
+Any code that relies on the specific format of the request errors raised by the apiclient will need to be updated.
+
 ## 17.0.0
 
 PR: [#143](https://github.com/alphagov/digitalmarketplace-apiclient/pull/143)

--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '17.4.0'
+__version__ = '18.0.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/base.py
+++ b/dmapiclient/base.py
@@ -168,7 +168,7 @@ class BaseAPIClient(object):
                     'api_method': method,
                     'api_url': url,
                     'api_status': api_error.status_code,
-                    'api_error': api_error.message,
+                    'api_error': '{} raised {}'.format(api_error.message, str(e)),
                     'api_time': elapsed_time,
                 },
             )

--- a/dmapiclient/errors.py
+++ b/dmapiclient/errors.py
@@ -1,5 +1,5 @@
 REQUEST_ERROR_STATUS_CODE = 503
-REQUEST_ERROR_MESSAGE = "Request failed"
+REQUEST_ERROR_MESSAGE = "Unknown request failure in dmapiclient"
 
 
 class APIError(Exception):
@@ -28,9 +28,12 @@ class APIError(Exception):
 class HTTPError(APIError):
     @staticmethod
     def create(e):
-        error = HTTPError(e.response)
+        fallback_message = '{}\n{}'.format(str(e), repr(e))
+
+        error = HTTPError(e.response, fallback_message)
         if error.status_code in [502, 503, 504]:
-            error = HTTPTemporaryError(e.response)
+            error = HTTPTemporaryError(e.response, fallback_message)
+
         return error
 
 


### PR DESCRIPTION
 ## Summary
We have been getting some mystery 503s in the buyer-frontend and don't
get any useful error information from the apiclient. This update causes
the apiclient to emit more useful information via the str() and repr()
calls on the base error.