### PR TITLE
Add retry to base api client requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 Records breaking changes from major version bumps
 
+## 19.0.0
+
+PR: [#152](https://github.com/alphagov/digitalmarketplace-apiclient/pull/152)
+
+We're now using urllib3's Retry util to retry failed requests made by the base api client. This has allowed us to
+remove backoff from `make_iter_method` and so also remove the package from the api client's dependencies. It also means
+that we no longer need `HTTPTemporaryError` so it's been removed.
+
+Anything that uses the api client and has it's own backoff setup (such as some of our scripts)
+will need to adjust (or remove) their config to prevent potentially making far too many retry requests.
+
+Anything that uses `HTTPTemporaryError` will need to remove it. The only place I've found it is in a few one off scripts
+in the scripts repo for backoff setup.
+
 ## 18.0.0
 
 PR: [#151](https://github.com/alphagov/digitalmarketplace-apiclient/pull/151)

--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '18.2.0'
+__version__ = '19.0.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '18.1.0'
+__version__ = '18.2.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/base.py
+++ b/dmapiclient/base.py
@@ -7,6 +7,8 @@ except ImportError:
     import urllib.parse as urlparse
 
 import requests
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
 from flask import has_request_context, request, current_app
 
 import backoff
@@ -50,6 +52,11 @@ def make_iter_method(method_name, *model_names):
 
 
 class BaseAPIClient(object):
+    RETRIES = 3
+    RETRIES_BACKOFF_FACTOR = 0.3
+    #  Respose status codes to retry on.
+    RETRIES_FORCE_STATUS_CODES = (500, 502, 503, 504)
+
     def __init__(self, base_url=None, auth_token=None, enabled=True):
         self.base_url = base_url
         self.auth_token = auth_token
@@ -104,6 +111,22 @@ class BaseAPIClient(object):
 
         return r.url
 
+    def _requests_retry_session(self):
+        session = requests.Session()
+        retry = Retry(
+            total=self.RETRIES,
+            read=self.RETRIES,
+            connect=self.RETRIES,
+            status=self.RETRIES,
+            backoff_factor=self.RETRIES_BACKOFF_FACTOR,
+            status_forcelist=self.RETRIES_FORCE_STATUS_CODES,
+            raise_on_status=False,
+        )
+        adapter = HTTPAdapter(max_retries=retry)
+        session.mount('http://', adapter)
+        session.mount('https://', adapter)
+        return session
+
     def _request(self, method, url, data=None, params=None):
         if not self.enabled:
             return None
@@ -153,7 +176,7 @@ class BaseAPIClient(object):
 
         start_time = monotonic()
         try:
-            response = requests.request(
+            response = self._requests_retry_session().request(
                 method, url,
                 headers=ci_headers, json=data)
             response.raise_for_status()

--- a/dmapiclient/errors.py
+++ b/dmapiclient/errors.py
@@ -30,19 +30,7 @@ class HTTPError(APIError):
     def create(e):
         fallback_message = '{}\n{}'.format(str(e), repr(e))
 
-        error = HTTPError(e.response, fallback_message)
-        if error.status_code in [502, 503, 504]:
-            error = HTTPTemporaryError(e.response, fallback_message)
-
-        return error
-
-
-class HTTPTemporaryError(HTTPError):
-    """Specific instance of HTTPError for temporary 502, 503 and 504 errors
-
-    Used for detecting whether failed requests should be retried.
-    """
-    pass
+        return HTTPError(e.response, fallback_message)
 
 
 class InvalidResponse(APIError):

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
     include_package_data=True,
     install_requires=[
         'Flask==0.10.1',
-        'backoff==1.0.7',
         'monotonic==0.3',
         'requests==2.18.4',
         'six==1.11.0'

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -2501,22 +2501,6 @@ class TestDataAPIClientIterMethods(object):
 
         assert len(results) == 2
 
-    @pytest.mark.parametrize("status_code", [
-        502, 503, 504
-    ])
-    @mock.patch('time.sleep')
-    def test_find_services_backoff_on_502_503_504(self, sleep, data_client, rmock, status_code):
-        rmock.get(
-            'http://baseurl/services',
-            [{'json': {}, 'status_code': status_code},
-             {'json': {'links': {}, 'services': [{'id': 1}]}, 'status_code': 200}])
-
-        result = data_client.find_services_iter()
-        results = list(result)
-
-        assert sleep.called
-        assert len(results) == 1
-
     def test_find_direct_award_projects_iter(self, data_client, rmock):
         self._test_find_iter(
             data_client, rmock,


### PR DESCRIPTION
See [this related PR on utils to add logging for this.](https://github.com/alphagov/digitalmarketplace-utils/pull/427)

This was heavily influenced by this blog post: [https://www.peterbe.com/plog/best-practice-with-retries-with-requests](https://www.peterbe.com/plog/best-practice-with-retries-with-requests)

This will allow the api client to retry requests which raise connection
errors, read errors, as well as requests that return certain 500 error codes.

For the tests, I've had to reach quite a long way in to the requests and
urllib3 modules. This is because response_mock (rmock fixture) mocks the
adapter that requests uses. Doing this means that we never actually
retry anything. I was torn between doing this potentially quite fragile
testing method, or just testing that Retry was called correctly when a
request was made. I am very open to changing this if people think this is a
bad idea.