### PR TITLE
Add export_users_iter and export_suppliers_iter methods

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '19.0.0'
+__version__ = '19.1.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -320,6 +320,9 @@ class DataAPIClient(BaseAPIClient):
             "/suppliers/export/{}".format(framework_slug)
         )
 
+    export_suppliers_iter = make_iter_method('export_suppliers', 'suppliers')
+    export_suppliers_iter.__name__ = str("export_suppliers_iter")
+
     # Users
 
     def create_user(self, user):
@@ -462,6 +465,9 @@ class DataAPIClient(BaseAPIClient):
         return self._get(
             "/users/export/{}".format(framework_slug)
         )
+
+    export_users_iter = make_iter_method('export_users', 'users')
+    export_users_iter.__name__ = str("export_users_iter")
 
     def is_email_address_with_valid_buyer_domain(self, email_address):
         return self._get(

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -2546,3 +2546,21 @@ class TestDataAPIClientIterMethods(object):
             url_path='direct-award/projects/1/services',
             iter_kwargs={'project_id': 1}
         )
+
+    def test_export_users_iter(self, data_client, rmock):
+        self._test_find_iter(
+            data_client, rmock,
+            method_name='export_users_iter',
+            model_name='users',
+            url_path='users/export/g-cloud-9',
+            iter_kwargs={'framework_slug': 'g-cloud-9'}
+        )
+
+    def test_export_suppliers_iter(self, data_client, rmock):
+        self._test_find_iter(
+            data_client, rmock,
+            method_name='export_suppliers_iter',
+            model_name='suppliers',
+            url_path='suppliers/export/g-cloud-9',
+            iter_kwargs={'framework_slug': 'g-cloud-9'}
+        )


### PR DESCRIPTION
Trello: https://trello.com/c/1sy265Zw/495-api-client-methods-for-exportusersiter-and-exportsuppliersiter

This has been in the Quick Wins column for 6 weeks 😹 Doing this now as it'll help improve our slow requests target.

TODO: The other parts of this puzzle:
- make the API endpoints for these methods paginated
- use the new `*_iter` methods in the apps/scripts.