### PR TITLE
Add data_supplier_id param to `find_audit_events`

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '19.1.0'
+__version__ = '19.2.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -23,11 +23,13 @@ class DataAPIClient(BaseAPIClient):
             latest_first=None,
             earliest_for_each_object=None,
             user=None,
+            data_supplier_id=None,
     ):
 
         params = {
             "acknowledged": acknowledged,
             "audit-date": audit_date,
+            "data-supplier-id": data_supplier_id,
             "earliest_for_each_object": earliest_for_each_object,
             "latest_first": latest_first,
             "object-id": object_id,

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -1363,11 +1363,22 @@ class TestAuditEventMethods(object):
         assert result == {"audit-event": "result"}
         assert rmock.called
 
+    def test_find_audit_events_with_data_supplier_id(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/audit-events?data-supplier-id=123456",
+            json={"audit-event": "result"},
+            status_code=200)
+
+        result = data_client.find_audit_events(data_supplier_id=123456)
+
+        assert result == {"audit-event": "result"}
+        assert rmock.called
+
     def test_find_audit_events_with_all_params(self, data_client, rmock):
         url = (
             "http://baseurl/audit-events?object-type=foo&object-id=34&acknowledged=all&latest_first=True"
             "&audit-date=2010-01-01&page=12&audit-type=contact_update&per_page=23&earliest_for_each_object=True"
-            "&user=ruby.cohen@example.com"
+            "&user=ruby.cohen@example.com&data-supplier-id=123456"
         )
         rmock.get(
             url,
@@ -1376,16 +1387,17 @@ class TestAuditEventMethods(object):
         )
 
         result = data_client.find_audit_events(
-            audit_type=AuditTypes.contact_update,
+            acknowledged='all',
             audit_date='2010-01-01',
+            audit_type=AuditTypes.contact_update,
+            data_supplier_id=123456,
+            earliest_for_each_object=True,
+            latest_first=True,
             page=12,
             per_page=23,
-            acknowledged='all',
-            object_type='foo',
             object_id=34,
-            user="ruby.cohen@example.com",
-            latest_first=True,
-            earliest_for_each_object=True)
+            object_type='foo',
+            user="ruby.cohen@example.com")
 
         assert result == {"audit-event": "result"}
         assert rmock.called


### PR DESCRIPTION
For [this trello ticket.](https://trello.com/c/AdtcNmBR)
See [this associated PR on the api.
](https://github.com/alphagov/digitalmarketplace-api/pull/826)

The api now accepts this parameter to filter audit events by the
supplierId field of the audit events data json blob, if it exists.