### PR TITLE
Remove requirement on virtualenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VIRTUALENV_ROOT := $(shell [ -z $$VIRTUAL_ENV ] && echo $$(pwd)/venv || echo $$V
 
 .PHONY: virtualenv
 virtualenv:
-	[ -z $$VIRTUAL_ENV ] && [ ! -d venv ] && virtualenv -p python3 venv || true
+	[ -z $$VIRTUAL_ENV ] && [ ! -d venv ] && python3 -m venv venv || true
 
 .PHONY: requirements-dev
 requirements-dev: virtualenv requirements-dev.txt

--- a/default.nix
+++ b/default.nix
@@ -12,7 +12,7 @@ in (with args; {
     name = "digitalmarketplace-apiclient-env";
     shortName = "dm-apicl";
     buildInputs = [
-      pythonPackages.virtualenv
+      pythonPackages.python
       pkgs.git
       pkgs.cacert
     ] ++ pkgs.stdenv.lib.optionals forDev ([
@@ -34,7 +34,7 @@ in (with args; {
       export PS1="\[\e[0;36m\](nix-shell\[\e[0m\]:\[\e[0;36m\]${shortName})\[\e[0;32m\]\u@\h\[\e[0m\]:\[\e[0m\]\[\e[0;36m\]\w\[\e[0m\]\$ "
 
       if [ ! -e $VIRTUALENV_ROOT ]; then
-        ${pythonPackages.virtualenv}/bin/virtualenv $VIRTUALENV_ROOT
+        ${pythonPackages.python}/bin/python -m venv $VIRTUALENV_ROOT
       fi
       source $VIRTUALENV_ROOT/bin/activate
       pip install -r requirements${pkgs.stdenv.lib.optionalString forDev "-dev"}.txt


### PR DESCRIPTION
Python36 includes the venv module which means we no longer need virtualenv to be installed on the development system