### PR TITLE
Add method for transition-dos endpoint

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '19.2.0'
+__version__ = '19.3.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -654,6 +654,13 @@ class DataAPIClient(BaseAPIClient):
             user=user
         )
 
+    def transition_dos_framework(self, framework_slug, expiring_framework_slug, user):
+        return self._post_with_updated_by(
+            "/frameworks/transition-dos/{}".format(framework_slug),
+            data={"expiringFramework": expiring_framework_slug},
+            user=user,
+        )
+
     def get_interested_suppliers(self, framework_slug):
         return self._get(
             "/frameworks/{}/interest".format(framework_slug)

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -1621,6 +1621,24 @@ class TestFrameworkMethods(object):
             "updated_by": "me@my.mine"
         }
 
+    def test_transition_dos_framework(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/frameworks/transition-dos/dos-22",
+            json={"returned": "framework"},
+            status_code=200
+        )
+
+        result = data_client.transition_dos_framework(
+            framework_slug="dos-22", expiring_framework_slug="dos-21", user="Clem Fandango"
+        )
+
+        assert result == {"returned": "framework"}
+        assert rmock.called
+        assert rmock.request_history[0].json() == {
+            "expiringFramework": "dos-21",
+            "updated_by": "Clem Fandango",
+        }
+
 
 class TestBriefMethods(object):
     def test_create_brief(self, data_client, rmock):


### PR DESCRIPTION
See [this closed PR ](https://github.com/alphagov/digitalmarketplace-api/pull/836)adding the endpoint to the API.

We have an new endpoint for transitioning DOS frameworks. This allows
the apiclient to call it.