### PR TITLE
Update setup.py requirements

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '19.3.0'
+__version__ = '19.4.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@
 coverage==3.7.1
 flake8==3.5.0
 flake8-per-file-ignores==0.4.0
+Flask<1.1,>=0.10.1
 mock==2.0.0
 pytest==3.2.3
 pytest-cov==2.5.1

--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,5 @@ setup(
         'monotonic>=0.3',
         'requests<3,>=2.18.4',
         'six<2,>=1.11.0'
-    ] + ([] if has_enum else ['enum34==1.1.6'])
+    ] + ([] if has_enum else ['enum34<2,>=1.1.6'])
 )

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,6 @@ setup(
         'Flask<1.1,>=1.0.2',
         'monotonic==0.3',
         'requests==2.18.4',
-        'six==1.11.0'
+        'six<2,>=1.11.0'
     ] + ([] if has_enum else ['enum34==1.1.6'])
 )

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'Flask==0.10.1',
+        'Flask<1.1,>=1.0.2',
         'monotonic==0.3',
         'requests==2.18.4',
         'six==1.11.0'

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,8 @@ setup(
     include_package_data=True,
     install_requires=[
         'Flask<1.1,>=1.0.2',
-        'requests==2.18.4',
         'monotonic>=0.3',
+        'requests<3,>=2.18.4',
         'six<2,>=1.11.0'
     ] + ([] if has_enum else ['enum34==1.1.6'])
 )

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'Flask<1.1,>=1.0.2',
         'monotonic>=0.3',
         'requests<3,>=2.18.4',
         'six<2,>=1.11.0'

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,8 @@ setup(
     include_package_data=True,
     install_requires=[
         'Flask<1.1,>=1.0.2',
-        'monotonic==0.3',
         'requests==2.18.4',
+        'monotonic>=0.3',
         'six<2,>=1.11.0'
     ] + ([] if has_enum else ['enum34==1.1.6'])
 )


### PR DESCRIPTION
When I rebuild the virtualenv for an app which has been updated to Flask 1.0.2, I get errors similar to:

```
digitalmarketplace-apiclient 19.0.0 has requirement Flask==0.10.1, but you'll have flask 1.0.2 which is incompatible.
```

This PR should fix this issue by pinning us to sensible version ranges for each dependency.