### PR TITLE
BaseAPIClient: add a `timeout` constructor argument for controlling the timeout of connections

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '19.5.0'
+__version__ = '19.6.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/base.py
+++ b/dmapiclient/base.py
@@ -53,7 +53,7 @@ class BaseAPIClient(object):
     #  Respose status codes to retry on.
     RETRIES_FORCE_STATUS_CODES = (500, 502, 503, 504)
 
-    def __init__(self, base_url=None, auth_token=None, enabled=True, timeout=45):
+    def __init__(self, base_url=None, auth_token=None, enabled=True, timeout=(15, 45,)):
         self.base_url = base_url
         self.auth_token = auth_token
         self.enabled = enabled

--- a/dmapiclient/base.py
+++ b/dmapiclient/base.py
@@ -53,10 +53,11 @@ class BaseAPIClient(object):
     #  Respose status codes to retry on.
     RETRIES_FORCE_STATUS_CODES = (500, 502, 503, 504)
 
-    def __init__(self, base_url=None, auth_token=None, enabled=True):
+    def __init__(self, base_url=None, auth_token=None, enabled=True, timeout=45):
         self.base_url = base_url
         self.auth_token = auth_token
         self.enabled = enabled
+        self.timeout = timeout
 
     def _patch(self, url, data):
         return self._request("PATCH", url, data=data)
@@ -173,8 +174,12 @@ class BaseAPIClient(object):
         start_time = monotonic()
         try:
             response = self._requests_retry_session().request(
-                method, url,
-                headers=ci_headers, json=data)
+                method,
+                url,
+                headers=ci_headers,
+                json=data,
+                timeout=self.timeout
+            )
             response.raise_for_status()
         except requests.RequestException as e:
             api_error = HTTPError.create(e)


### PR DESCRIPTION
Fell out of https://trello.com/c/aWnL8fAa/192-antivirus-create-catch-up-bulk-scan-script

Turns out we've never had timeouts set on the api client. This means requests can wait indefinitely. In the apps, it means they will continue to the point that the parent request times out the whole app request (usually it is the router that ends up doing this). In scripts it means they can hang pretty much indefinitely.

How do people feel about 45s as an initial default? I've made this a constructor argument instead of a pseudo-constant (a la `RETRIES`) because it feels we're going to want to adjust this more often.

Would people like me to add an `init_app` implementation that can pull this value from app config?