### PR TITLE
antivirus api: switch to sending PUT requests for scan_and_tag_s3_object 

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '19.6.0'
+__version__ = '19.7.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/antivirus.py
+++ b/dmapiclient/antivirus.py
@@ -7,7 +7,7 @@ class AntivirusAPIClient(BaseAPIClient):
         self.auth_token = app.config['DM_ANTIVIRUS_API_AUTH_TOKEN']
 
     def scan_and_tag_s3_object(self, bucket_name, object_key, object_version_id):
-        return self._post(
+        return self._put(
             "/scan/s3-object",
             data={
                 "bucketName": bucket_name,

--- a/tests/test_antivirus_api_client.py
+++ b/tests/test_antivirus_api_client.py
@@ -36,7 +36,7 @@ class TestAntivirusApiClient(object):
 
 class TestServiceMethods(object):
     def test_scan_and_tag_s3_object(self, antivirus_client, rmock):
-        rmock.post(
+        rmock.put(
             "http://baseurl/scan/s3-object",
             json={"Clappy": "clapclap"},
             status_code=200,


### PR DESCRIPTION
https://trello.com/c/ZSg7FK5s/201-apiclient-sort-out-timeouts-retrying-once-for-all

Following rollout of https://github.com/alphagov/digitalmarketplace-antivirus-api/pull/18 the antivirus api will accept `PUT` requests for `scan_and_tag_s3_object`'s endpoint. The reasoning is covered there.