### PR TITLE
Adds method for accessing the endpoint

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '19.8.0'
+__version__ = '19.9.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -183,6 +183,14 @@ class DataAPIClient(BaseAPIClient):
             user=user
         )
 
+    def remove_supplier_declaration(self, supplier_id, framework_slug, user):
+        return self._post_with_updated_by(
+            "/suppliers/{}/frameworks/{}/declaration".format(
+                supplier_id, framework_slug),
+            data={},
+            user=user
+        )
+
     def get_supplier_frameworks(self, supplier_id):
         return self._get(
             "/suppliers/{}/frameworks".format(supplier_id)

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -798,6 +798,21 @@ class TestSupplierMethods(object):
             'updated_by': 'user',
             'declaration': {'question': 'answer'}}
 
+    def test_remove_supplier_declaration(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/suppliers/123/frameworks/g-cloud-7/declaration",
+            json={"supplierFramework": "serialized_object"},
+            status_code=200
+        )
+
+        result = data_client.remove_supplier_declaration(123, 'g-cloud-7', "user")
+
+        assert result == {"supplierFramework": "serialized_object"}
+        assert rmock.called
+        assert rmock.request_history[0].json() == {
+            'updated_by': "user"
+        }
+
     def test_get_supplier_frameworks(self, data_client, rmock):
         rmock.get(
             "http://baseurl/suppliers/123/frameworks",


### PR DESCRIPTION
This commit adds a method to the apiclient that allows a user to remove a declaration on a supplier_framework. It's implemented by calling a pre-existing method to DRY the code out as much as possible.

[Ticket](https://trello.com/c/xhq2Vy7l/211-update-apiclient-with-method-for-removing-supplierframework-declarations)