### PR TITLE
Support Python 3.6 only

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '19.9.0'
+__version__ = '19.9.1'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,6 @@ setup(
         'monotonic>=0.3',
         'requests<3,>=2.18.4',
         'six<2,>=1.11.0'
-    ] + ([] if has_enum else ['enum34<2,>=1.1.6'])
+    ] + ([] if has_enum else ['enum34<2,>=1.1.6']),
+    python_requires="==3.6.*",
 )


### PR DESCRIPTION
Add python_requires specification to setup.py that explicitly declares which versions of Python this library supports/is tested on.

Part of https://trello.com/c/wWFsv1SU/230-be-clear-in-our-libraries-what-versions-of-python-we-support