### PR TITLE
remove monotonic dependency in favour of time.perf_counter 

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '19.9.1'
+__version__ = '19.9.2'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/base.py
+++ b/dmapiclient/base.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 import logging
+import time
 
 try:
     import urlparse
@@ -10,8 +11,6 @@ import requests
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 from flask import has_request_context, request, current_app
-
-from monotonic import monotonic
 
 from . import __version__
 from .errors import APIError, HTTPError, InvalidResponse
@@ -171,7 +170,7 @@ class BaseAPIClient(object):
             },
         )
 
-        start_time = monotonic()
+        start_time = time.perf_counter()
         try:
             response = self._requests_retry_session().request(
                 method,
@@ -183,7 +182,7 @@ class BaseAPIClient(object):
             response.raise_for_status()
         except requests.RequestException as e:
             api_error = HTTPError.create(e)
-            elapsed_time = monotonic() - start_time
+            elapsed_time = time.perf_counter() - start_time
             logger.log(
                 logging.INFO if api_error.status_code == 404 else logging.WARNING,
                 "API {api_method} request on {api_url} failed with {api_status} '{api_error}'",
@@ -198,7 +197,7 @@ class BaseAPIClient(object):
             )
             raise api_error
         else:
-            elapsed_time = monotonic() - start_time
+            elapsed_time = time.perf_counter() - start_time
             logger.log(
                 logging.INFO,
                 "API {api_method} request on {api_url} finished in {api_time}",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'monotonic>=0.3',
         'requests<3,>=2.18.4',
         'six<2,>=1.11.0'
     ] + ([] if has_enum else ['enum34<2,>=1.1.6']),


### PR DESCRIPTION
https://trello.com/c/2LfWhgkp/257-remove-use-of-monotonic-in-apiclient-and-utils

Again, I chose time.perf_counter, a cousin of the new time.monotonic for the same reasons I did so when creating logged_duration. That is, I can't remember the exact difference right now, but we're basically using it for the same thing here as I was there.