### PR TITLE
Add Python badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Digital Marketplace API client
 
 [![Coverage Status](https://coveralls.io/repos/alphagov/digitalmarketplace-apiclient/badge.svg?branch=master&service=github)](https://coveralls.io/github/alphagov/digitalmarketplace-apiclient?branch=master)
 [![Requirements Status](https://requires.io/github/alphagov/digitalmarketplace-apiclient/requirements.svg?branch=master)](https://requires.io/github/alphagov/digitalmarketplace-apiclient/requirements/?branch=master)
+![Python 3.6](https://img.shields.io/badge/python-3.6-blue.svg)
 
 ## What's in here?
 

--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '19.9.2'
+__version__ = '19.9.3'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa


### PR DESCRIPTION
Adds a nifty visual indicator of what versions of Python we support

Part of https://trello.com/c/wWFsv1SU/230-be-clear-in-our-libraries-what-versions-of-python-we-support