### PR TITLE
Supplier search by Company registration number

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '19.9.3'
+__version__ = '19.10.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -93,7 +93,9 @@ class DataAPIClient(BaseAPIClient):
 
     # Suppliers
 
-    def find_suppliers(self, prefix=None, page=None, framework=None, duns_number=None):
+    def find_suppliers(
+        self, prefix=None, page=None, framework=None, duns_number=None, company_registration_number=None
+    ):
         params = {}
         if prefix:
             params["prefix"] = prefix
@@ -103,6 +105,8 @@ class DataAPIClient(BaseAPIClient):
             params['framework'] = framework
         if duns_number is not None:
             params['duns_number'] = duns_number
+        if company_registration_number is not None:
+            params['company_registration_number'] = company_registration_number
 
         return self._get(
             "/suppliers",

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -635,6 +635,17 @@ class TestSupplierMethods(object):
         assert result == {"services": "result"}
         assert rmock.called
 
+    def test_find_suppliers_with_company_registration_number(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/suppliers?company_registration_number=12345678",
+            json={"suppliers": "result"},
+            status_code=200)
+
+        result = data_client.find_suppliers(company_registration_number='12345678')
+
+        assert result == {"suppliers": "result"}
+        assert rmock.called
+
     def test_find_supplier_adds_page_parameter(self, data_client, rmock):
         rmock.get(
             "http://baseurl/suppliers?page=2",


### PR DESCRIPTION
Trello: https://trello.com/c/tZJCxC87/249-new-admin-search-box-for-suppliers

Small change, to supply an extra search parameter `company_registration_number` to the `find_suppliers` method. See https://github.com/alphagov/digitalmarketplace-api/pull/849 for details.