### PR TITLE
Remove six library

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '19.10.0'
+__version__ = '19.11.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/base.py
+++ b/dmapiclient/base.py
@@ -211,7 +211,7 @@ class BaseAPIClient(object):
             )
         try:
             return response.json()
-        except ValueError as e:
+        except ValueError:
             raise InvalidResponse(response,
                                   message="No JSON object could be decoded")
 

--- a/dmapiclient/search.py
+++ b/dmapiclient/search.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import re
-import six
 try:
     from urllib.parse import urlparse, urlencode, urlunparse, parse_qsl
 except ImportError:
@@ -36,7 +35,7 @@ class SearchAPIClient(BaseAPIClient):
 
     def _add_filters_prefix_to_params(self, params, filters):
         """In-place transformation of filter keys and storage in params."""
-        for filter_name, filter_values in six.iteritems(filters):
+        for filter_name, filter_values in filters.items():
             params[u'filter_{}'.format(filter_name)] = filter_values
 
     def _remove_filters_prefix_from_params(self, search_api_params):

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,6 @@
 import re
 import ast
-import sys
 from setuptools import setup, find_packages
-
-
-has_enum = sys.version_info >= (3, 4)
 
 
 _version_re = re.compile(r'__version__\s+=\s+(.*)')
@@ -25,7 +21,6 @@ setup(
     include_package_data=True,
     install_requires=[
         'requests<3,>=2.18.4',
-        'six<2,>=1.11.0'
-    ] + ([] if has_enum else ['enum34<2,>=1.1.6']),
+    ],
     python_requires="==3.6.*",
 )


### PR DESCRIPTION
This PR is to remove uses of the `six` library. I've replaced them with their python 3 equivalents. I've also updated `setup.py` 

[Ticket](https://trello.com/c/AdmER908/149-remove-python2-deps-from-apiclient)