### PR TITLE
Add name keyword to find_suppliers

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '19.12.0'
+__version__ = '19.13.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -94,11 +94,13 @@ class DataAPIClient(BaseAPIClient):
     # Suppliers
 
     def find_suppliers(
-        self, prefix=None, page=None, framework=None, duns_number=None, company_registration_number=None
+        self, prefix=None, page=None, framework=None, duns_number=None, company_registration_number=None, name=None
     ):
         params = {}
         if prefix:
             params["prefix"] = prefix
+        if name:
+            params["name"] = name
         if page is not None:
             params['page'] = page
         if framework is not None:

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -613,6 +613,17 @@ class TestSupplierMethods(object):
         assert result == {"services": "result"}
         assert rmock.called
 
+    def test_find_suppliers_with_name(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/suppliers?name=a",
+            json={"services": "result"},
+            status_code=200)
+
+        result = data_client.find_suppliers(name='a')
+
+        assert result == {"services": "result"}
+        assert rmock.called
+
     def test_find_suppliers_with_framework(self, data_client, rmock):
         rmock.get(
             "http://baseurl/suppliers?framework=gcloud",


### PR DESCRIPTION
Trello: https://trello.com/c/aSOduJAQ/319-admin-search-for-registered-name-as-well-as-supplier-name

Allow the apps to search the API by supplier name or registered name. See https://github.com/alphagov/digitalmarketplace-api/pull/859 for details.

Tested this locally with the Admin FE.