### PR TITLE
Update test dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,9 @@
 -r requirements.txt
 coverage==4.5.2
-flake8==3.6.0
-flake8-per-file-ignores==0.7
+flake8==3.7.5
 Flask<1.1,>=0.10.1
 mock==2.0.0
-pytest==4.1.1
+pytest==4.2.0
 pytest-cov==2.6.1
 python-coveralls==2.9.1
 requests-mock==1.5.2


### PR DESCRIPTION
Supersedes the current open PyUp PRs for this repo.

`flake8` now supports per-file-ignores well enough for our purposes. This means we can remove the extra `flake8-per-file-ignores` dependency.