### PR TITLE
Add get_buyer_email_domains methods

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '20.0.0'
+__version__ = '20.1.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -499,6 +499,16 @@ class DataAPIClient(BaseAPIClient):
             "/users/check-buyer-email", params={'email_address': email_address}
         )['valid']
 
+    def get_buyer_email_domains(self, page=None):
+        params = {}
+        if page is not None:
+            params["page"] = page
+
+        return self._get("/buyer-email-domains", params=params)
+
+    get_buyer_email_domains_iter = make_iter_method("get_buyer_email_domains", "buyerEmailDomains")
+    get_buyer_email_domains_iter.__name__ = str("get_buyer_email_domains_iter")
+
     def create_buyer_email_domain(self, buyer_email_domain, user):
         return self._post_with_updated_by(
             "/buyer-email-domains",

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -549,6 +549,27 @@ class TestBuyerDomainMethods(object):
         assert rmock.called
         assert result is False
 
+    def test_get_buyer_email_domains(self, data_client, rmock):
+        expected = {"buyerEmailDomains": [{"domainName": "gov.uk", "id": "1"}]}
+        rmock.get(
+            "http://baseurl/buyer-email-domains",
+            json=expected,
+            status_code=200,
+        )
+
+        got = data_client.get_buyer_email_domains()
+        assert expected == got
+
+    def test_get_buyer_email_domains_can_have_page(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/buyer-email-domains?page=2",
+            json={},
+            status_code=200,
+        )
+
+        data_client.get_buyer_email_domains(page=2)
+        assert rmock.called
+
     def test_create_buyer_email_domain(self, data_client, rmock):
         rmock.post(
             "http://baseurl/buyer-email-domains",
@@ -2663,5 +2684,14 @@ class TestDataAPIClientIterMethods(object):
             method_name='find_outcomes_iter',
             model_name='outcomes',
             url_path='outcomes',
+            iter_kwargs={},
+        )
+
+    def test_get_buyer_email_domains_iter(self, data_client, rmock):
+        self._test_find_iter(
+            data_client, rmock,
+            method_name="get_buyer_email_domains_iter",
+            model_name="buyerEmailDomains",
+            url_path="buyer-email-domains",
             iter_kwargs={},
         )


### PR DESCRIPTION
We've had a request from CCS to see the list of approved email address domains for buyers (https://trello.com/c/h0CbxA9t/754-domain-whitelist-for-buyers). In future we might also want to add an admin frontend view that displays this info (https://trello.com/c/4LinvI5X/810-allow-admin-framework-manager-to-view-list-of-trusted-buyer-email-domains).

This commit adds a method to grab a page from the `/buyer-email-domains api endpoint`, and also an iter method so that you can easily fetch all values in one go.