### PR TITLE
BaseAPIClient: make writeable attributes private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Records breaking changes from major version bumps
 
+## 21.0.0
+
+All "attributes" of apiclient instances have been made private and replaced with read-only properties of the same name.
+This is to encourage use of apiclients as objects that are unmutated after construction, making their use (hopefully)
+threadsafe.
+
+The attributes in question comprise `RETRIES`, `RETRIES_BACKOFF_FACTOR`, `RETRIES_FORCE_STATUS_CODES`, `base_url`,
+`auth_token`, `enabled`, `timeout`. It seems unlikely that any code was mutating these values
+post-construction/`init_app`, but it's worth doing a check before upgrading.
+
 ## 20.0.0
 
 PR: [#205](https://github.com/alphagov/digitalmarketplace-apiclient/pull/205)

--- a/default.nix
+++ b/default.nix
@@ -7,12 +7,24 @@ let
     forDev = true;
     localOverridesPath = ./local.nix;
   } // argsOuter;
+  sitePrioNonNix = args.pkgs.writeTextFile {
+    name = "site-prio-non-nix";
+    destination = "/${args.pythonPackages.python.sitePackages}/sitecustomize.py";
+    text = ''
+      import sys
+      first_nix_i = next((i for i, p in enumerate(sys.path) if p.startswith("/nix/")), 1)
+      # after the first nix-provided path in sys.path (presumably the python stdlib itself), re-sort all non-nix
+      # paths to be before the nix paths. this is helped by python's sort being a stable-sort
+      sys.path[first_nix_i+1:] = sorted(sys.path[first_nix_i+1:], key=lambda p: p.startswith("/nix/"))
+    '';
+  };
 in (with args; {
   digitalMarketplaceAPIClientEnv = (pkgs.stdenv.mkDerivation rec {
     name = "digitalmarketplace-apiclient-env";
     shortName = "dm-apicl";
     buildInputs = [
       pythonPackages.python
+      sitePrioNonNix
       pkgs.glibcLocales
       pkgs.git
       pkgs.cacert

--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '20.2.0'
+__version__ = '21.0.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/antivirus.py
+++ b/dmapiclient/antivirus.py
@@ -3,8 +3,8 @@ from .base import BaseAPIClient
 
 class AntivirusAPIClient(BaseAPIClient):
     def init_app(self, app):
-        self.base_url = app.config['DM_ANTIVIRUS_API_URL']
-        self.auth_token = app.config['DM_ANTIVIRUS_API_AUTH_TOKEN']
+        self._base_url = app.config['DM_ANTIVIRUS_API_URL']
+        self._auth_token = app.config['DM_ANTIVIRUS_API_AUTH_TOKEN']
 
     def scan_and_tag_s3_object(self, bucket_name, object_key, object_version_id):
         return self._put(

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -6,8 +6,8 @@ from .errors import HTTPError
 
 class DataAPIClient(BaseAPIClient):
     def init_app(self, app):
-        self.base_url = app.config['DM_DATA_API_URL']
-        self.auth_token = app.config['DM_DATA_API_AUTH_TOKEN']
+        self._base_url = app.config['DM_DATA_API_URL']
+        self._auth_token = app.config['DM_DATA_API_AUTH_TOKEN']
 
     # Audit Events
 

--- a/dmapiclient/search.py
+++ b/dmapiclient/search.py
@@ -14,9 +14,9 @@ from .errors import HTTPError
 
 class SearchAPIClient(BaseAPIClient):
     def init_app(self, app):
-        self.base_url = app.config['DM_SEARCH_API_URL']
-        self.auth_token = app.config['DM_SEARCH_API_AUTH_TOKEN']
-        self.enabled = app.config['ES_ENABLED']
+        self._base_url = app.config['DM_SEARCH_API_URL']
+        self._auth_token = app.config['DM_SEARCH_API_AUTH_TOKEN']
+        self._enabled = app.config['ES_ENABLED']
 
     def _url(self, index, path, doc_type='services'):
         return u"/{}/{}/{}".format(index, doc_type, path)

--- a/tests/test_base_api_client.py
+++ b/tests/test_base_api_client.py
@@ -54,7 +54,7 @@ class TestBaseApiClient(object):
     ))
     @pytest.mark.parametrize('retry_count', range(1, 4))
     @mock.patch('urllib3.connectionpool.HTTPConnectionPool._make_request')
-    @mock.patch('dmapiclient.base.BaseAPIClient.RETRIES_BACKOFF_FACTOR', 0)
+    @mock.patch('dmapiclient.base.BaseAPIClient._RETRIES_BACKOFF_FACTOR', 0)
     def test_client_retries_on_httperror_and_raises_api_error(
         self,
         _make_request,
@@ -65,7 +65,7 @@ class TestBaseApiClient(object):
     ):
         _make_request.side_effect = exc_factory()
 
-        with mock.patch('dmapiclient.base.BaseAPIClient.RETRIES', retry_count):
+        with mock.patch('dmapiclient.base.BaseAPIClient._RETRIES', retry_count):
             with pytest.raises(HTTPError) as e:
                 base_client._request(method, '/')
 
@@ -84,7 +84,7 @@ class TestBaseApiClient(object):
     @pytest.mark.parametrize("method", ("POST", "PATCH",))
     @pytest.mark.parametrize('retry_count', range(1, 4))
     @mock.patch('urllib3.connectionpool.HTTPConnectionPool._make_request')
-    @mock.patch('dmapiclient.base.BaseAPIClient.RETRIES_BACKOFF_FACTOR', 0)
+    @mock.patch('dmapiclient.base.BaseAPIClient._RETRIES_BACKOFF_FACTOR', 0)
     def test_client_doesnt_retry_non_whitelisted_methods_on_unsafe_errors(
         self,
         _make_request,
@@ -95,7 +95,7 @@ class TestBaseApiClient(object):
     ):
         _make_request.side_effect = exc_factory()
 
-        with mock.patch('dmapiclient.base.BaseAPIClient.RETRIES', retry_count):
+        with mock.patch('dmapiclient.base.BaseAPIClient._RETRIES', retry_count):
             with pytest.raises(HTTPError) as e:
                 base_client._request(method, '/')
 
@@ -112,14 +112,14 @@ class TestBaseApiClient(object):
     @pytest.mark.parametrize(('status'), BaseAPIClient.RETRIES_FORCE_STATUS_CODES)
     @mock.patch('urllib3.connectionpool.HTTPConnectionPool.ResponseCls.from_httplib')
     @mock.patch('urllib3.connectionpool.HTTPConnectionPool._make_request')
-    @mock.patch('dmapiclient.base.BaseAPIClient.RETRIES_BACKOFF_FACTOR', 0)
+    @mock.patch('dmapiclient.base.BaseAPIClient._RETRIES_BACKOFF_FACTOR', 0)
     def test_client_retries_on_status_error_and_raises_api_error(
         self, _make_request, from_httplib, base_client, status, retry_count
     ):
         response_mock = self._from_httplib_response_mock(status)
         from_httplib.return_value = response_mock
 
-        with mock.patch('dmapiclient.base.BaseAPIClient.RETRIES', retry_count):
+        with mock.patch('dmapiclient.base.BaseAPIClient._RETRIES', retry_count):
             with pytest.raises(HTTPError) as e:
                 base_client._request("GET", '/')
 
@@ -133,7 +133,7 @@ class TestBaseApiClient(object):
 
     @mock.patch('urllib3.connectionpool.HTTPConnectionPool.ResponseCls.from_httplib')
     @mock.patch('urllib3.connectionpool.HTTPConnectionPool._make_request')
-    @mock.patch('dmapiclient.base.BaseAPIClient.RETRIES_BACKOFF_FACTOR', 0)
+    @mock.patch('dmapiclient.base.BaseAPIClient._RETRIES_BACKOFF_FACTOR', 0)
     def test_client_retries_and_returns_data_if_successful(self, _make_request, from_httplib, base_client):
         #  The third response here would normally be a httplib response object. It's only use is to be passed in to
         #  `from_httplib`, which we're mocking the return of below. `from_httplib` converts a httplib response into a

--- a/tests/test_search_api_client.py
+++ b/tests/test_search_api_client.py
@@ -136,7 +136,7 @@ class TestSearchApiClient(object):
 
     def test_should_not_call_search_api_if_es_disabled(
             self, search_client, rmock):
-        search_client.enabled = False
+        search_client._enabled = False
         rmock.put(
             'http://baseurl/g-cloud/services/12345',
             json={'message': 'acknowledged'},


### PR DESCRIPTION
God knows where the ticket for this is if it ever had one - it's been kicking around for a while.

This is to encourage immutabile use of api clients after construction/init_app, which should provide more threadsafety.