### PR TITLE
DataAPIClient: add set_supplier_framework_allow_declaration_reuse

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '20.1.0'
+__version__ = '20.2.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -226,6 +226,16 @@ class DataAPIClient(BaseAPIClient):
             user=user,
         )
 
+    def set_supplier_framework_allow_declaration_reuse(self, supplier_id, framework_slug, allow, user):
+        return self._post_with_updated_by(
+            "/suppliers/{}/frameworks/{}".format(
+                supplier_id, framework_slug),
+            data={
+                "frameworkInterest": {"allowDeclarationReuse": allow},
+            },
+            user=user,
+        )
+
     def set_supplier_framework_prefill_declaration(
         self,
         supplier_id,

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -904,6 +904,20 @@ class TestSupplierMethods(object):
             'updated_by': 'user'
         }
 
+    def test_set_supplier_framework_allow_declaration_reuse(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/suppliers/123/frameworks/g-cloud-7",
+            json={"frameworkInterest": {"allowDeclarationReuse": True}},
+            status_code=200)
+
+        result = data_client.set_supplier_framework_allow_declaration_reuse(123, 'g-cloud-7', True, "user")
+        assert result == {"frameworkInterest": {"allowDeclarationReuse": True}}
+        assert rmock.called
+        assert rmock.request_history[0].json() == {
+            'frameworkInterest': {'allowDeclarationReuse': True},
+            'updated_by': 'user'
+        }
+
     def test_set_supplier_framework_prefill_declaration(self, data_client, rmock):
         rmock.post(
             "http://baseurl/suppliers/8765/frameworks/breeches",


### PR DESCRIPTION
https://trello.com/c/V7cUDIRW

All for the purpose of being able to _set_ this flag, yup, need a new apiclient method.