### PR TITLE
add client_wait_for_response option to some method calls

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '21.1.0'
+__version__ = '21.2.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/base.py
+++ b/dmapiclient/base.py
@@ -108,36 +108,36 @@ class BaseAPIClient(object):
         self._enabled = enabled
         self._timeout = timeout
 
-    def _patch(self, url, data):
-        return self._request("PATCH", url, data=data)
+    def _patch(self, url, data, *, client_wait_for_response: bool = True):
+        return self._request("PATCH", url, data=data, client_wait_for_response=client_wait_for_response)
 
-    def _patch_with_updated_by(self, url, data, user):
+    def _patch_with_updated_by(self, url, data, user, *, client_wait_for_response: bool = True):
         data = dict(data, updated_by=user)
-        return self._patch(url, data)
+        return self._patch(url, data, client_wait_for_response=client_wait_for_response)
 
-    def _put(self, url, data):
-        return self._request("PUT", url, data=data)
+    def _put(self, url, data, *, client_wait_for_response: bool = True):
+        return self._request("PUT", url, data=data, client_wait_for_response=client_wait_for_response)
 
-    def _put_with_updated_by(self, url, data, user):
+    def _put_with_updated_by(self, url, data, user, *, client_wait_for_response: bool = True):
         data = dict(data, updated_by=user)
-        return self._put(url, data)
+        return self._put(url, data, client_wait_for_response=client_wait_for_response)
 
-    def _get(self, url, params=None):
-        return self._request("GET", url, params=params)
+    def _get(self, url, params=None, *, client_wait_for_response: bool = True):
+        return self._request("GET", url, params=params, client_wait_for_response=client_wait_for_response)
 
-    def _post(self, url, data):
-        return self._request("POST", url, data=data)
+    def _post(self, url, data, *, client_wait_for_response: bool = True):
+        return self._request("POST", url, data=data, client_wait_for_response=client_wait_for_response)
 
-    def _post_with_updated_by(self, url, data, user):
+    def _post_with_updated_by(self, url, data, user, *, client_wait_for_response: bool = True):
         data = dict(data, updated_by=user)
-        return self._post(url, data)
+        return self._post(url, data, client_wait_for_response=client_wait_for_response)
 
-    def _delete(self, url, data=None):
-        return self._request("DELETE", url, data=data)
+    def _delete(self, url, data=None, *, client_wait_for_response: bool = True):
+        return self._request("DELETE", url, data=data, client_wait_for_response=client_wait_for_response)
 
-    def _delete_with_updated_by(self, url, data, user):
+    def _delete_with_updated_by(self, url, data, user, *, client_wait_for_response: bool = True):
         data = dict(data, updated_by=user)
-        return self._delete(url, data)
+        return self._delete(url, data, client_wait_for_response=client_wait_for_response)
 
     def _build_url(self, url, params):
         if not self._base_url:

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -671,9 +671,13 @@ class DataAPIClient(BaseAPIClient):
     find_services_iter = make_iter_method('find_services', 'services')
     find_services_iter.__name__ = str("find_services_iter")
 
-    def update_service(self, service_id, service, user, user_role=''):
+    def update_service(self, service_id, service, user, user_role='', *, wait_for_index: bool = True):
         return self._post_with_updated_by(
-            "/services/{}{}".format(service_id, "?user-role={}".format(user_role) if user_role else ""),
+            "/services/{}?{}{}".format(
+                service_id,
+                "&wait-for-index={}".format(str(wait_for_index).lower()),
+                "&user-role={}".format(user_role) if user_role else "",
+            ),
             data={
                 "services": service,
             },

--- a/dmapiclient/search.py
+++ b/dmapiclient/search.py
@@ -100,9 +100,17 @@ class SearchAPIClient(BaseAPIClient):
             data={'type': 'alias', 'target': target_index}
         )
 
-    def index(self, index_name, object_id, serialized_object, doc_type='services'):
+    def index(
+        self,
+        index_name,
+        object_id,
+        serialized_object,
+        doc_type='services',
+        *,
+        client_wait_for_response: bool = True,
+    ):
         url = '/{}/{}/{}'.format(index_name, doc_type, object_id)
-        return self._put(url, data={'document': serialized_object})
+        return self._put(url, data={'document': serialized_object}, client_wait_for_response=client_wait_for_response)
 
     def delete(self, index, service_id):
         url = self._url(index, service_id)

--- a/tests/test_base_api_client.py
+++ b/tests/test_base_api_client.py
@@ -16,7 +16,7 @@ from dmapiclient import HTTPError, InvalidResponse
 from dmapiclient.errors import REQUEST_ERROR_STATUS_CODE
 from dmapiclient.exceptions import ImproperlyConfigured
 
-from urllib3.exceptions import NewConnectionError, ProtocolError, ReadTimeoutError
+from urllib3.exceptions import NewConnectionError, ProtocolError, ReadTimeoutError, MaxRetryError
 
 
 @pytest.yield_fixture
@@ -376,3 +376,84 @@ class TestBaseApiClient(object):
                 rmock.last_request.headers.get("x-brian-tweedy")
                 or rmock.last_request.headers.get("major-tweedy")
             ) == mock_logger.log.call_args_list[0][1]["extra"]["childSpanId"]
+
+    @pytest.mark.parametrize("thrown_exception", (
+        # requests can be slightly unpredictable in the exceptions it raises
+        requests.exceptions.ConnectionError(
+            MaxRetryError(mock.Mock(), "http://abc.net", ReadTimeoutError(mock.Mock(), mock.Mock(), mock.Mock()))
+        ),
+        requests.exceptions.ConnectionError(ReadTimeoutError(mock.Mock(), mock.Mock(), mock.Mock())),
+        requests.exceptions.ReadTimeout,
+    ))
+    @mock.patch("dmapiclient.base.logger")
+    def test_nowait_times_out(
+        self,
+        mock_logger,
+        base_client,
+        rmock,
+        app,
+        thrown_exception,
+    ):
+        "test the case when a request with client_wait_for_response=False does indeed time out"
+        rmock.post("http://baseurl/services/10000", exc=thrown_exception)
+
+        retval = base_client._request(
+            "POST",
+            "/services/10000",
+            {"serviceName": "Postcard"},
+            client_wait_for_response=False,
+        )
+
+        assert retval is None
+
+        assert rmock.called
+        assert tuple(req.timeout for req in rmock.request_history) == (base_client.nowait_timeout,)
+
+        assert mock_logger.log.call_args_list == [
+            mock.call(logging.DEBUG, "API request {method} {url}", extra={
+                "method": "POST",
+                "url": "http://baseurl/services/10000",
+            }),
+            mock.call(logging.INFO, "API {api_method} request on {api_url} dispatched but ignoring response", extra={
+                "api_method": "POST",
+                "api_url": "http://baseurl/services/10000",
+                "api_time": mock.ANY,
+                "api_time_incomplete": True,
+            }),
+        ]
+
+    @mock.patch("dmapiclient.base.logger")
+    def test_nowait_completes(
+        self,
+        mock_logger,
+        base_client,
+        rmock,
+        app,
+    ):
+        "test the case when a request with client_wait_for_response=False completes before it can time out"
+        rmock.post("http://baseurl/services/10000", json={"services": {"id": "10000"}}, status_code=200)
+
+        retval = base_client._request(
+            "POST",
+            "/services/10000",
+            {"serviceName": "Postcard"},
+            client_wait_for_response=False,
+        )
+
+        assert retval == {"services": {"id": "10000"}}
+
+        assert rmock.called
+        assert tuple(req.timeout for req in rmock.request_history) == (base_client.nowait_timeout,)
+
+        assert mock_logger.log.call_args_list == [
+            mock.call(logging.DEBUG, "API request {method} {url}", extra={
+                "method": "POST",
+                "url": "http://baseurl/services/10000",
+            }),
+            mock.call(logging.INFO, "API {api_method} request on {api_url} finished in {api_time}", extra={
+                "api_method": "POST",
+                "api_url": "http://baseurl/services/10000",
+                "api_time": mock.ANY,
+                "api_status": 200,
+            }),
+        ]

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -115,7 +115,7 @@ class TestServiceMethods(object):
 
     def test_update_service(self, data_client, rmock):
         rmock.post(
-            "http://baseurl/services/123",
+            "http://baseurl/services/123?&wait-for-index=true",
             json={"services": "result"},
             status_code=200,
         )
@@ -126,15 +126,19 @@ class TestServiceMethods(object):
         assert result == {"services": "result"}
         assert rmock.called
 
-    def test_update_service_by_admin(self, data_client, rmock):
+    @pytest.mark.parametrize("wait_for_index_call_arg,wait_for_index_req_arg", (
+        (False, "false"),
+        (True, "true"),
+    ))
+    def test_update_service_by_admin(self, data_client, rmock, wait_for_index_call_arg, wait_for_index_req_arg):
         rmock.post(
-            "http://baseurl/services/123?user-role=admin",
+            f"http://baseurl/services/123?&wait-for-index={wait_for_index_req_arg}&user-role=admin",
             json={"services": "result"},
             status_code=200,
         )
 
         result = data_client.update_service(
-            123, {"foo": "bar"}, "person", user_role='admin')
+            123, {"foo": "bar"}, "person", user_role='admin', wait_for_index=wait_for_index_call_arg)
 
         assert result == {"services": "result"}
         assert rmock.called

--- a/tests/test_search_api_client.py
+++ b/tests/test_search_api_client.py
@@ -69,19 +69,30 @@ class TestSearchApiClient(object):
             "target": 'target'
         }
 
+    @pytest.mark.parametrize("client_wait_for_response", (False, True,))
     def test_post_to_index_with_type_and_id(
-            self, search_client, rmock):
+        self,
+        search_client,
+        rmock,
+        client_wait_for_response,
+    ):
         rmock.put(
             'http://baseurl/briefs-digital-outcomes-and-specialists-2/briefs/12345',
             json={'message': 'acknowledged'},
-            status_code=200)
+            status_code=200,
+        )
         result = search_client.index(
             'briefs-digital-outcomes-and-specialists-2',
             "12345",
             {'serialized': 'brief'},
             doc_type='briefs',
+            client_wait_for_response=client_wait_for_response,
         )
         assert result == {'message': 'acknowledged'}
+
+        assert tuple(req.timeout for req in rmock.request_history) == (
+            search_client.timeout if client_wait_for_response else search_client.nowait_timeout,
+        )
 
     def test_post_to_index_without_type_defaults_to_services(
             self, search_client, rmock):


### PR DESCRIPTION
This is a part of a potential way of addressing https://trello.com/c/LABe8BKA

The pattern it introduces is something I like to call async-not-async. It's simply allows a user of the `apiclient` to perform a highly simplified form of async http request by ignoring the response from the server. It does this by setting the read timeout to something tiny and allowing that timeout to happen. It relies on the fact that web server stacks tend not to readily propagate "the client is gone" information, and a request will continue to be processed fully, even after the client has given up.

In the case we're proposing to use it it gives us basically all the advantages of true async but also all the perils: how easy it is to launch hundreds of requests in a couple of milliseconds without considering how the recipient will deal with it. Pushed too far, what we'd effectively end up doing is using our http servers' connection buffers as a not-very-good task queue, which could lead to healthcheck failures.

Why prefix the kwarg with `client_`? Because previously all arguments passed to apiclient methods implied they were referring to **server** options. This is the first relating to **client** behaviour, and the distinction could start to get ambiguous if and when we start doing things like adding a server-side option to the `api`'s `update_service` endpoint to instruct it to perform _its_ daisychained `index` request to the `search-api` without waiting for the response.