### PR TITLE
add more client_wait_for_response, wait_for_index options

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '21.2.0'
+__version__ = '21.3.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -684,9 +684,13 @@ class DataAPIClient(BaseAPIClient):
             user=user,
         )
 
-    def update_service_status(self, service_id, status, user):
+    def update_service_status(self, service_id, status, user, *, wait_for_index: bool = True):
         return self._post_with_updated_by(
-            "/services/{}/status/{}".format(service_id, status),
+            "/services/{}/status/{}{}".format(
+                service_id,
+                status,
+                "?wait-for-index={}".format(str(wait_for_index).lower()),
+            ),
             data={},
             user=user,
         )

--- a/dmapiclient/search.py
+++ b/dmapiclient/search.py
@@ -112,11 +112,11 @@ class SearchAPIClient(BaseAPIClient):
         url = '/{}/{}/{}'.format(index_name, doc_type, object_id)
         return self._put(url, data={'document': serialized_object}, client_wait_for_response=client_wait_for_response)
 
-    def delete(self, index, service_id):
+    def delete(self, index, service_id, *, client_wait_for_response: bool = True):
         url = self._url(index, service_id)
 
         try:
-            return self._delete(url)
+            return self._delete(url, client_wait_for_response=client_wait_for_response)
         except HTTPError as e:
             if e.status_code != 404:
                 raise

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -143,15 +143,19 @@ class TestServiceMethods(object):
         assert result == {"services": "result"}
         assert rmock.called
 
-    def test_update_service_status(self, data_client, rmock):
+    @pytest.mark.parametrize("wait_for_index_call_arg,wait_for_index_req_arg", (
+        (False, "false"),
+        (True, "true"),
+    ))
+    def test_update_service_status(self, data_client, rmock, wait_for_index_call_arg, wait_for_index_req_arg):
         rmock.post(
-            "http://baseurl/services/123/status/published",
+            f"http://baseurl/services/123/status/published?wait-for-index={wait_for_index_req_arg}",
             json={"services": "result"},
             status_code=200,
         )
 
         result = data_client.update_service_status(
-            123, "published", "person")
+            123, "published", "person", wait_for_index=wait_for_index_call_arg)
 
         assert result == {"services": "result"}
         assert rmock.called

--- a/tests/test_search_api_client.py
+++ b/tests/test_search_api_client.py
@@ -107,8 +107,13 @@ class TestSearchApiClient(object):
         )
         assert result == {'message': 'acknowledged'}
 
+    @pytest.mark.parametrize("client_wait_for_response", (False, True,))
     def test_delete_to_delete_method_service_id(
-            self, search_client, rmock):
+        self,
+        search_client,
+        rmock,
+        client_wait_for_response
+    ):
         rmock.delete(
             'http://baseurl/g-cloud/services/12345',
             json={"services": {
@@ -119,8 +124,16 @@ class TestSearchApiClient(object):
                 "found": True
             }},
             status_code=200)
-        result = search_client.delete(index='g-cloud', service_id="12345")
+        result = search_client.delete(
+            index='g-cloud',
+            service_id="12345",
+            client_wait_for_response=client_wait_for_response,
+        )
         assert result['services']['found'] is True
+
+        assert tuple(req.timeout for req in rmock.request_history) == (
+            search_client.timeout if client_wait_for_response else search_client.nowait_timeout,
+        )
 
     def test_delete_raises_if_http_error_not_404(
             self, search_client, rmock):


### PR DESCRIPTION
When attempting to implement https://trello.com/c/LABe8BKA it would be helpful to add these options to the actual api calls that the admin view in question uses in the first place.

So add `wait_for_index` option to `DataApiClient.update_service_status()`.

Also since the api's view corresponding to `update_service_status` can also _delete_ items from the index, using `SearchAPIClient.delete()`, we need to add the `client_wait_for_response` argument to _it_.