### PR TITLE
DataAPIClient.find_brief_responses(): add with_data parameter

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '21.3.0'
+__version__ = '21.4.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -881,7 +881,16 @@ class DataAPIClient(BaseAPIClient):
         return self._get(
             "/brief-responses/{}".format(brief_response_id))
 
-    def find_brief_responses(self, brief_id=None, supplier_id=None, status=None, framework=None, awarded_at=None):
+    def find_brief_responses(
+        self,
+        brief_id=None,
+        supplier_id=None,
+        status=None,
+        framework=None,
+        awarded_at=None,
+        *,
+        with_data: bool = None,
+    ):
         return self._get(
             "/brief-responses",
             params={
@@ -889,7 +898,8 @@ class DataAPIClient(BaseAPIClient):
                 "supplier_id": supplier_id,
                 "status": status,
                 "framework": framework,
-                "awarded_at": awarded_at
+                "awarded_at": awarded_at,
+                "with-data": str(with_data).lower() if with_data is not None else None,
             })
 
     find_brief_responses_iter = make_iter_method('find_brief_responses', 'briefResponses')

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -2162,7 +2162,7 @@ class TestBriefResponseMethods(object):
     def test_find_brief_responses(self, data_client, rmock):
         url = (
             "http://baseurl/brief-responses?brief_id=1&supplier_id=2&status=draft&"
-            "framework=digital-outcomes-and-specialists-2&awarded_at=2018-01-01"
+            "framework=digital-outcomes-and-specialists-2&awarded_at=2018-01-01&with-data=false"
         )
         rmock.get(
             url,
@@ -2170,8 +2170,12 @@ class TestBriefResponseMethods(object):
             status_code=200)
 
         result = data_client.find_brief_responses(
-            brief_id=1, supplier_id=2, status='draft', framework='digital-outcomes-and-specialists-2',
-            awarded_at="2018-01-01"
+            brief_id=1,
+            supplier_id=2,
+            status='draft',
+            framework='digital-outcomes-and-specialists-2',
+            awarded_at="2018-01-01",
+            with_data=False,
         )
 
         assert result == {"briefResponses": []}


### PR DESCRIPTION
https://trello.com/c/2FBIg5LP

Didn't give this a default in the end.