### PR TITLE
Remove upper restriction on Python versions

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '21.4.0'
+__version__ = '21.4.1'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,5 @@ setup(
     install_requires=[
         'requests<3,>=2.18.4',
     ],
-    python_requires="==3.6.*",
+    python_requires="~=3.6",
 )


### PR DESCRIPTION
https://trello.com/c/GsDBHBo7/135-switch-on-python-37-and-38-travis-checks-to-check-potential-dependency-problems-before-upgrade

The ~= syntax denotes we don't fully support higher versions yet:
https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires

See equivalent PR for utils: https://github.com/alphagov/digitalmarketplace-utils/pull/544