### PR TITLE
DataAPIClient.update_service(): add page_questions argument and tests

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '21.4.1'
+__version__ = '21.5.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+
+import typing
+
 from .audit import AuditTypes
 from .base import BaseAPIClient, logger, make_iter_method
 from .errors import HTTPError
@@ -671,7 +674,16 @@ class DataAPIClient(BaseAPIClient):
     find_services_iter = make_iter_method('find_services', 'services')
     find_services_iter.__name__ = str("find_services_iter")
 
-    def update_service(self, service_id, service, user, user_role='', *, wait_for_index: bool = True):
+    def update_service(
+        self,
+        service_id,
+        service,
+        user,
+        user_role='',
+        *,
+        wait_for_index: bool = True,
+        page_questions: typing.Optional[typing.List[str]] = None,
+    ):
         return self._post_with_updated_by(
             "/services/{}?{}{}".format(
                 service_id,
@@ -680,6 +692,7 @@ class DataAPIClient(BaseAPIClient):
             ),
             data={
                 "services": service,
+                "page_questions": page_questions or [],
             },
             user=user,
         )

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -124,13 +124,31 @@ class TestServiceMethods(object):
             123, {"foo": "bar"}, "person")
 
         assert result == {"services": "result"}
-        assert rmock.called
+        assert tuple(req.json() for req in rmock.request_history) == (
+            {
+                'services': {'foo': 'bar'},
+                'page_questions': [],
+                'updated_by': 'person',
+            },
+        )
 
     @pytest.mark.parametrize("wait_for_index_call_arg,wait_for_index_req_arg", (
         (False, "false"),
         (True, "true"),
     ))
-    def test_update_service_by_admin(self, data_client, rmock, wait_for_index_call_arg, wait_for_index_req_arg):
+    @pytest.mark.parametrize("page_questions_arg,expected_page_questions", (
+        (None, []),
+        (["u", "p", "up"], ["u", "p", "up"]),
+    ))
+    def test_update_service_by_admin(
+        self,
+        data_client,
+        rmock,
+        wait_for_index_call_arg,
+        wait_for_index_req_arg,
+        page_questions_arg,
+        expected_page_questions,
+    ):
         rmock.post(
             f"http://baseurl/services/123?&wait-for-index={wait_for_index_req_arg}&user-role=admin",
             json={"services": "result"},
@@ -138,10 +156,22 @@ class TestServiceMethods(object):
         )
 
         result = data_client.update_service(
-            123, {"foo": "bar"}, "person", user_role='admin', wait_for_index=wait_for_index_call_arg)
+            123,
+            {"foo": "bar"},
+            "important@person",
+            user_role='admin',
+            wait_for_index=wait_for_index_call_arg,
+            page_questions=page_questions_arg,
+        )
 
         assert result == {"services": "result"}
-        assert rmock.called
+        assert tuple(req.json() for req in rmock.request_history) == (
+            {
+                'services': {'foo': 'bar'},
+                'page_questions': expected_page_questions,
+                'updated_by': 'important@person',
+            },
+        )
 
     @pytest.mark.parametrize("wait_for_index_call_arg,wait_for_index_req_arg", (
         (False, "false"),


### PR DESCRIPTION
To aid https://trello.com/c/ShyReqk5

Analogous to same argument on `.update_brief()` method, this has been supported by the API for a long time but never exposed by the apiclient.