### PR TITLE
Add new AuditType for updating the supplier on a service

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '21.4.1'
+__version__ = '21.5.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/audit.py
+++ b/dmapiclient/audit.py
@@ -26,6 +26,7 @@ class AuditTypes(Enum):
     update_service = "update_service"
     update_service_admin = "update_service_admin"
     update_service_status = "update_service_status"
+    update_service_supplier = "update_service_supplier"
 
     # Brief lifecycle events
     create_brief = "create_brief"


### PR DESCRIPTION
https://trello.com/c/mLU7vty9/1343-inconsistency-with-supplier-on-the-dos4-framework-amaze-realize

A new audit event type will be needed to link two supplier IDs on the same audit event.