### PR TITLE
use POST email address methods

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '21.6.0'
+__version__ = '21.7.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -515,8 +515,8 @@ class DataAPIClient(BaseAPIClient):
     export_users_iter.__name__ = str("export_users_iter")
 
     def is_email_address_with_valid_buyer_domain(self, email_address):
-        return self._get(
-            "/users/check-buyer-email", params={'email_address': email_address}
+        return self._post(
+            "/users/check-buyer-email", data={'emailAddress': email_address}
         )['valid']
 
     def get_buyer_email_domains(self, page=None):
@@ -539,8 +539,8 @@ class DataAPIClient(BaseAPIClient):
         )
 
     def email_is_valid_for_admin_user(self, email_address):
-        return self._get(
-            "/users/valid-admin-email", params={'email_address': email_address}
+        return self._post(
+            "/users/valid-admin-email", data={'emailAddress': email_address}
         )['valid']
 
     # Services

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -628,6 +628,7 @@ class TestEmailVaildForAdminMethod(object):
             status_code=200
         )
         result = data_client.email_is_valid_for_admin_user('kev@gov.uk')
+        assert rmock.last_request.json() == {"emailAddress": "kev@gov.uk"}
         assert rmock.called
         assert result is True
 
@@ -638,6 +639,7 @@ class TestEmailVaildForAdminMethod(object):
             status_code=200
         )
         result = data_client.email_is_valid_for_admin_user('kev@not-gov.uk')
+        assert rmock.last_request.json() == {"emailAddress": "kev@not-gov.uk"}
         assert rmock.called
         assert result is False
 

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -569,6 +569,7 @@ class TestBuyerDomainMethods(object):
             status_code=200)
         result = data_client.is_email_address_with_valid_buyer_domain('kev@gov.uk')
         assert rmock.called
+        assert rmock.last_request.json() == {'emailAddress': 'kev@gov.uk'}
         assert result is True
 
     def test_is_email_address_with_valid_buyer_domain_false(self, data_client, rmock):
@@ -578,6 +579,7 @@ class TestBuyerDomainMethods(object):
             status_code=200)
         result = data_client.is_email_address_with_valid_buyer_domain('kev@ymail.com')
         assert rmock.called
+        assert rmock.last_request.json() == {'emailAddress': 'kev@ymail.com'}
         assert result is False
 
     def test_get_buyer_email_domains(self, data_client, rmock):

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -563,8 +563,8 @@ class TestUserMethods(object):
 
 class TestBuyerDomainMethods(object):
     def test_is_email_address_with_valid_buyer_domain_true(self, data_client, rmock):
-        rmock.get(
-            "http://baseurl/users/check-buyer-email?email_address=kev%40gov.uk",
+        rmock.post(
+            "http://baseurl/users/check-buyer-email",
             json={"valid": True},
             status_code=200)
         result = data_client.is_email_address_with_valid_buyer_domain('kev@gov.uk')
@@ -572,8 +572,8 @@ class TestBuyerDomainMethods(object):
         assert result is True
 
     def test_is_email_address_with_valid_buyer_domain_false(self, data_client, rmock):
-        rmock.get(
-            "http://baseurl/users/check-buyer-email?email_address=kev%40ymail.com",
+        rmock.post(
+            "http://baseurl/users/check-buyer-email",
             json={"valid": False},
             status_code=200)
         result = data_client.is_email_address_with_valid_buyer_domain('kev@ymail.com')
@@ -622,8 +622,8 @@ class TestBuyerDomainMethods(object):
 class TestEmailVaildForAdminMethod(object):
 
     def test_email_address_with_valid_admin_domain_is_true(self, data_client, rmock):
-        rmock.get(
-            "http://baseurl/users/valid-admin-email?email_address=kev%40gov.uk",
+        rmock.post(
+            "http://baseurl/users/valid-admin-email",
             json={"valid": True},
             status_code=200
         )
@@ -632,8 +632,8 @@ class TestEmailVaildForAdminMethod(object):
         assert result is True
 
     def test_email_address_with_invalid_admin_domain_is_false(self, data_client, rmock):
-        rmock.get(
-            "http://baseurl/users/valid-admin-email?email_address=kev%40not-gov.uk",
+        rmock.post(
+            "http://baseurl/users/valid-admin-email",
             json={"valid": False},
             status_code=200
         )


### PR DESCRIPTION
This updates the API client to use the methods introduced in https://github.com/alphagov/digitalmarketplace-api/pull/1037