### PR TITLE
Add create_framework method

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '21.8.0'
+__version__ = '21.9.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -721,6 +721,34 @@ class DataAPIClient(BaseAPIClient):
     def get_framework(self, slug):
         return self._get("/frameworks/{}".format(slug))
 
+    def create_framework(self,
+                         slug,
+                         name,
+                         framework_family_slug,
+                         lots,
+                         has_direct_award,
+                         has_further_competition,
+                         user,
+                         *,
+                         status="coming",
+                         clarification_questions_open=False):
+        framework_data = {
+            "slug": slug,
+            "name": name,
+            "framework": framework_family_slug,
+            "status": status,
+            "clarificationQuestionsOpen": clarification_questions_open,
+            "lots": lots,
+            "hasDirectAward": has_direct_award,
+            "hasFurtherCompetition": has_further_competition
+        }
+
+        return self._post_with_updated_by(
+            "/frameworks",
+            data={"frameworks": framework_data},
+            user=user
+        )
+
     def update_framework(self, framework_slug, data, user):
         return self._post_with_updated_by(
             "/frameworks/{}".format(framework_slug),

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -1709,6 +1709,31 @@ class TestAuditEventMethods(object):
 
 
 class TestFrameworkMethods(object):
+    def test_create_framework(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/frameworks",
+            json={"frameworks": "result"},
+            status_code=201,
+        )
+
+        result = data_client.create_framework(
+            "digital-things-2", "Digital Things", "digital-things", [], True, False, "user@email.com")
+
+        assert result == {"frameworks": "result"}
+        assert rmock.last_request.json() == {
+            'frameworks': {
+                'clarificationQuestionsOpen': False,
+                'framework': 'digital-things',
+                'hasDirectAward': True,
+                'hasFurtherCompetition': False,
+                'lots': [],
+                'name': 'Digital Things',
+                'slug': 'digital-things-2',
+                'status': 'coming'
+            },
+            'updated_by': 'user@email.com'
+        }
+
     def test_get_interested_suppliers(self, data_client, rmock):
         rmock.get(
             'http://baseurl/frameworks/g-cloud-11/interest',


### PR DESCRIPTION
This already exists in the API. I want to be able to create frameworks via the API client, though.