### PR TITLE
Document responses that are sometimes paginated

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '21.10.0'
+__version__ = '21.10.1'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -671,6 +671,9 @@ class DataAPIClient(BaseAPIClient):
         return None
 
     def find_services(self, supplier_id=None, framework=None, status=None, page=None, lot=None):
+        """
+        The response will be paginated unless you provide supplier_id.
+        """
         params = {
             'supplier_id': supplier_id,
             'framework': framework,
@@ -857,6 +860,9 @@ class DataAPIClient(BaseAPIClient):
         self, user_id=None, status=None, framework=None, lot=None, page=None, human=None, with_users=None,
         with_clarification_questions=None, closed_on=None, withdrawn_on=None, cancelled_on=None, unsuccessful_on=None
     ):
+        """
+        The response will be paginated unless you provide user_id.
+        """
         return self._get(
             "/briefs",
             params={"user_id": user_id,
@@ -932,6 +938,9 @@ class DataAPIClient(BaseAPIClient):
         *,
         with_data: bool = None,
     ):
+        """
+        The response will be paginated unless you provide supplier_id or brief_id.
+        """
         return self._get(
             "/brief-responses",
             params={


### PR DESCRIPTION
Some API endpoints are paginated and some are not. But there also exist three that may be paginated depending on the request parameters. This last category is rather confusing, so document them.