### PR TITLE
Bump digitalmarketplace-test-utils from git to PyPI

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,4 +10,4 @@ pytest==4.6.3
 pytest-cov==2.7.1
 requests-mock==1.7.0
 
-git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.6.2#egg=digitalmarketplace-test-utils==2.6.2
+git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.8.2#egg=digitalmarketplace-test-utils==2.8.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,4 +10,4 @@ pytest==4.6.3
 pytest-cov==2.7.1
 requests-mock==1.7.0
 
-git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.8.2#egg=digitalmarketplace-test-utils==2.8.2
+digitalmarketplace-test-utils<3.0.0,>=2.8.2


### PR DESCRIPTION
We want to install digitalmarketplace-test-utils from PyPI instead of VCS, so we can rely on Dependabot to update our apps automatically when a new version is available.