### PR TITLE
Add type hints to APIError methods

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '21.11.0'
+__version__ = '21.11.1'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/errors.py
+++ b/dmapiclient/errors.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 REQUEST_ERROR_STATUS_CODE = 503
 REQUEST_ERROR_MESSAGE = "Unknown request failure in dmapiclient"
 
@@ -8,14 +10,14 @@ class APIError(Exception):
         self._message = message
 
     @property
-    def message(self):
+    def message(self) -> Union[str, dict]:
         try:
             return self.response.json()['error']
         except (TypeError, ValueError, AttributeError, KeyError):
             return self._message or REQUEST_ERROR_MESSAGE
 
     @property
-    def status_code(self):
+    def status_code(self) -> int:
         try:
             return self.response.status_code
         except AttributeError:


### PR DESCRIPTION
https://trello.com/c/9RUq5TL8/1243-2-bug-emessage-passed-to-inappropriate-error-handler

The types are not as expected, which has caught people out before. Hopefully adding type hints will make the behaviour less surprising in future.