### PR TITLE
Add delete_buyer_email_domain audit event type

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '21.11.1'
+__version__ = '21.12.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/audit.py
+++ b/dmapiclient/audit.py
@@ -66,6 +66,7 @@ class AuditTypes(Enum):
     # Admin actions
     snapshot_framework_stats = "snapshot_framework_stats"
     create_buyer_email_domain = "create_buyer_email_domain"
+    delete_buyer_email_domain = "delete_buyer_email_domain"
 
     # Projects
     create_project = "create_project"


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/4475776

We're going to add a new API endpoint to allow us to delete domains from the buyer allow list. So we need a new audit event type.