### PR TITLE
Add type hint checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Records breaking changes from major version bumps
 
+## 22.0.0
+
+Mark this package as PEP 561 compatible. If you have dmapiclient as a dependency and run type checking, the type checker
+will now check that you're using dmapiclient correctly. This might break your application's type checking if you're 
+using dmapiclient incorrectly.
+
 ## 21.0.0
 
 All "attributes" of apiclient instances have been made private and replaced with read-only properties of the same name.

--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '21.13.0'
+__version__ = '22.0.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/base.py
+++ b/dmapiclient/base.py
@@ -137,7 +137,7 @@ class BaseAPIClient(object):
     def _post(self, url, data, *, client_wait_for_response: bool = True):
         return self._request("POST", url, data=data, client_wait_for_response=client_wait_for_response)
 
-    def _post_with_updated_by(self, url, data, *, user: Optional[str] = True, client_wait_for_response: bool = True):
+    def _post_with_updated_by(self, url, data, *, user: Optional[str] = None, client_wait_for_response: bool = True):
         user = self._getuser(user)
         data = dict(data, updated_by=user)
         return self._post(url, data, client_wait_for_response=client_wait_for_response)

--- a/dmapiclient/base.py
+++ b/dmapiclient/base.py
@@ -170,7 +170,8 @@ class BaseAPIClient(object):
 
     def _requests_retry_session(self, *, retry_read_timeouts: bool = True):
         session = requests.Session()
-        retry = Retry(
+        # TODO: remove ignore once requests' typeshed entry is correct (currently missing status and raise_on_status).
+        retry = Retry(  # type: ignore
             total=self._RETRIES,
             read=self._RETRIES if retry_read_timeouts else 0,
             connect=self._RETRIES,
@@ -212,11 +213,12 @@ class BaseAPIClient(object):
             "User-agent": "DM-API-Client/{}".format(__version__),
         }
         if has_request_context():
+            # Disable type checking for attributes added by RequestIdRequestMixin - mypy doesn't know about it.
             if callable(getattr(request, "get_onwards_request_headers", None)):
-                headers.update(request.get_onwards_request_headers())
+                headers.update(request.get_onwards_request_headers())  # type: ignore
             elif getattr(request, "request_id", None) and current_app.config.get("DM_REQUEST_ID_HEADER"):
                 # support old .request_id attr for compatibility
-                headers[current_app.config["DM_REQUEST_ID_HEADER"]] = request.request_id
+                headers[current_app.config["DM_REQUEST_ID_HEADER"]] = request.request_id  # type: ignore
 
         # not using CaseInsensitiveDict as our header dict initially as technically .update()'s behaviour is undefined
         # for it, but past a certain point we want to be able to know we've resolved what our final header value is

--- a/dmapiclient/base.py
+++ b/dmapiclient/base.py
@@ -2,18 +2,13 @@ from __future__ import absolute_import
 import logging
 import time
 from typing import Optional
-
-try:
-    import urlparse
-except ImportError:
-    import urllib.parse as urlparse
-
 import requests
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 from requests.exceptions import ReadTimeout
 from urllib3.exceptions import ReadTimeoutError
 from flask import has_request_context, request, current_app
+import urllib.parse as urlparse
 
 from . import __version__
 from .errors import APIError, HTTPError, InvalidResponse

--- a/dmapiclient/errors.py
+++ b/dmapiclient/errors.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, cast
 
 REQUEST_ERROR_STATUS_CODE = 503
 REQUEST_ERROR_MESSAGE = "Unknown request failure in dmapiclient"
@@ -12,14 +12,16 @@ class APIError(Exception):
     @property
     def message(self) -> Union[str, dict]:
         try:
-            return self.response.json()['error']
+            # If the API returns a well-formed `error`, it should always be a dict.
+            return cast(dict, self.response.json()['error'])
         except (TypeError, ValueError, AttributeError, KeyError):
             return self._message or REQUEST_ERROR_MESSAGE
 
     @property
     def status_code(self) -> int:
         try:
-            return self.response.status_code
+            # TODO: remove cast when requests adds type hints.
+            return cast(int, self.response.status_code)
         except AttributeError:
             return REQUEST_ERROR_STATUS_CODE
 

--- a/dmapiclient/search.py
+++ b/dmapiclient/search.py
@@ -3,12 +3,7 @@
 import re
 import warnings
 
-try:
-    from urllib.parse import urlparse, urlencode, urlunparse, parse_qsl
-except ImportError:
-    from urlparse import urlparse, urlunparse, parse_qsl
-    from urllib import urlencode
-
+from urllib.parse import urlparse, urlencode, urlunparse, parse_qsl
 
 from .base import BaseAPIClient, make_iter_method
 from .errors import HTTPError

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,6 @@
 [mypy]
 python_version = 3.6
+files = dmapiclient
 warn_return_any = True
 
 [mypy-urllib3.*]

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,9 @@
+[mypy]
+python_version = 3.6
+warn_return_any = True
+
+[mypy-urllib3.*]
+ignore_missing_imports = True
+
+[mypy-urlparse.*]
+ignore_missing_imports = True

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -6,6 +6,7 @@ coverage
 coveralls
 flake8
 mock
+mypy
 pytest
 pytest-cov
 requests-mock

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -50,6 +50,10 @@ mock==4.0.2
     # via -r requirements-dev.in
 more-itertools==8.7.0
     # via pytest
+mypy-extensions==0.4.3
+    # via mypy
+mypy==0.812
+    # via -r requirements-dev.in
 packaging==20.9
     # via pytest
 pluggy==0.13.1
@@ -79,8 +83,12 @@ six==1.15.0
     # via
     #   pytest
     #   requests-mock
+typed-ast==1.4.3
+    # via mypy
 typing-extensions==3.7.4.3
-    # via importlib-metadata
+    # via
+    #   importlib-metadata
+    #   mypy
 urllib3==1.26.4
     # via requests
 wcwidth==0.2.5

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     description='Digital Marketplace Data and Search API clients',
     long_description=__doc__,
     packages=find_packages(),
+    package_data={'dmapiclient': ['py.typed']},
     include_package_data=True,
     install_requires=[
         'requests<3,>=2.18.4',

--- a/tasks.py
+++ b/tasks.py
@@ -9,3 +9,4 @@ def test_mypy(c):
 
 
 ns.add_task(test_mypy)
+ns["test"].pre.insert(-1, test_mypy)

--- a/tasks.py
+++ b/tasks.py
@@ -5,7 +5,7 @@ from dmdevtools.invoke_tasks import library_tasks as ns
 
 @task(ns["virtualenv"], ns["requirements_dev"])
 def test_mypy(c):
-    c.run("mypy dmutils/")
+    c.run("mypy")
 
 
 ns.add_task(test_mypy)

--- a/tasks.py
+++ b/tasks.py
@@ -1,1 +1,11 @@
+from invoke import task
+
 from dmdevtools.invoke_tasks import library_tasks as ns
+
+
+@task(ns["virtualenv"], ns["requirements_dev"])
+def test_mypy(c):
+    c.run("mypy dmutils/")
+
+
+ns.add_task(test_mypy)


### PR DESCRIPTION
Use mypy to check the types in this library. Then mark the library as having type hints so consumers can use them.

Note that the type hinting is thus far rather sparse, so this will not yet be very useful to consumers.

Copied very heavily from https://github.com/alphagov/digitalmarketplace-utils/pull/606