### PR TITLE
Add support for status_date_filters to find_briefs

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '22.0.0'
+__version__ = '22.1.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import warnings
+from typing import Dict
 
 from .audit import AuditTypes
 from .base import BaseAPIClient, logger, make_iter_method
@@ -907,31 +908,41 @@ class DataAPIClient(BaseAPIClient):
 
     def find_briefs(
         self, user_id=None, status=None, framework=None, lot=None, page=None, human=None, with_users=None,
-        with_clarification_questions=None, closed_on=None, withdrawn_on=None, cancelled_on=None, unsuccessful_on=None
+        with_clarification_questions=None, closed_on=None, withdrawn_on=None, cancelled_on=None, unsuccessful_on=None,
+        status_date_filters: Dict[str, str] = None,
     ):
         """
         The response will be paginated unless you provide user_id.
+
+        :param status_date_filters: contains additional status date filters. For permitted keys, see `list_briefs` in
+        https://github.com/alphagov/digitalmarketplace-api/blob/main/app/main/views/briefs.py
         """
         warnings.warn(
             "The output of 'find_briefs' is paginated. Use 'find_briefs_iter' instead.",
             DeprecationWarning
         )
 
+        params = {
+            "user_id": user_id,
+            "framework": framework,
+            "lot": lot,
+            "status": status,
+            "page": page,
+            "human": human,
+            "with_users": with_users,
+            "with_clarification_questions": with_clarification_questions,
+            "closed_on": closed_on,
+            "withdrawn_on": withdrawn_on,
+            "cancelled_on": cancelled_on,
+            "unsuccessful_on": unsuccessful_on
+        }
+
+        if status_date_filters:
+            params.update(status_date_filters)
+
         return self._get(
             "/briefs",
-            params={"user_id": user_id,
-                    "framework": framework,
-                    "lot": lot,
-                    "status": status,
-                    "page": page,
-                    "human": human,
-                    "with_users": with_users,
-                    "with_clarification_questions": with_clarification_questions,
-                    "closed_on": closed_on,
-                    "withdrawn_on": withdrawn_on,
-                    "cancelled_on": cancelled_on,
-                    "unsuccessful_on": unsuccessful_on
-                    }
+            params=params
         )
 
     find_briefs_iter = make_iter_method('find_briefs', 'briefs')

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -2135,6 +2135,17 @@ class TestBriefMethods(object):
         assert rmock.called
         assert result == {"briefs": [{"unsuccessfulAt": "2017-10-20"}]}
 
+    def test_find_briefs_closed_after_date(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/briefs?closed_after=2017-10-20",
+            json={"briefs": [{"closedAfter": "2017-10-20"}]},
+            status_code=200)
+
+        result = data_client.find_briefs(status_date_filters={"closed_after": "2017-10-20"})
+
+        assert rmock.called
+        assert result == {"briefs": [{"closedAfter": "2017-10-20"}]}
+
     def test_find_briefs_with_clarification_questions(self, data_client, rmock):
         rmock.get(
             "http://baseurl/briefs?with_clarification_questions=True",


### PR DESCRIPTION
https://trello.com/c/FGm8bi13/3-2-suppliers-may-be-missing-out-on-opportunities-due-to-misleading-banner

There are 18 possible status_date_filters, so we don't want to add them all individually. Instead allow users to provide a dictionary and let the API work out whether it's correct or not.

This should make a spot of analysis I'm trying to do a bit easier.